### PR TITLE
Fix for RCS1140 adding an extra "/>

### DIFF
--- a/source/Core/CSharp/Refactorings/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentRefactoring.cs
+++ b/source/Core/CSharp/Refactorings/AddExceptionToDocumentationComment/AddExceptionToDocumentationCommentRefactoring.cs
@@ -377,7 +377,7 @@ namespace Roslynator.CSharp.Refactorings.AddExceptionToDocumentationComment
                 sb.Append("\"/>");
 
                 if (exceptionSymbol.Equals(semanticModel.GetTypeByMetadataName(MetadataNames.System_ArgumentNullException)))
-                    sb.Append("\"/> is <c>null</c>.");
+                    sb.Append(" is <c>null</c>.");
             }
 
             sb.Append("</exception>");


### PR DESCRIPTION
When the `<exception>` is an `ArgumentNullException`, `"/>` was added twice - minor bug. Here's an example of the current behavior before this fix:
<img width="964" alt="screen shot 2017-02-18 at 08 55 50" src="https://cloud.githubusercontent.com/assets/454813/23093685/49fd807e-f5b8-11e6-906f-80f8af8b61b1.png">
