### PR TITLE
Add refactoring ReplaceStringLiteralWithStringFormat

### DIFF
--- a/source/Refactorings/RefactoringIdentifiers.Generated.cs
+++ b/source/Refactorings/RefactoringIdentifiers.Generated.cs
@@ -154,6 +154,7 @@ namespace Roslynator.CSharp.Refactorings
         public const string ReplaceStringContainsWithStringIndexOf = Prefix + "0144";
         public const string ReplaceStringFormatWithInterpolatedString = Prefix + "0145";
         public const string ReplaceStringLiteralWithCharacterLiteral = Prefix + "0146";
+        public const string ReplaceStringLiteralWithStringFormat = Prefix + "0180";
         public const string ReplaceSwitchWithIfElse = Prefix + "0147";
         public const string ReplaceVerbatimStringLiteralWithRegularStringLiteral = Prefix + "0148";
         public const string ReplaceVerbatimStringLiteralWithRegularStringLiterals = Prefix + "0149";

--- a/source/Refactorings/Refactorings.csproj
+++ b/source/Refactorings/Refactorings.csproj
@@ -280,6 +280,7 @@
     <Compile Include="Refactorings\UsingDirectiveRefactoring.cs" />
     <Compile Include="Refactorings\ThrowStatementRefactoring.cs" />
     <Compile Include="Refactorings\WrapInElseClauseRefactoring.cs" />
+    <Compile Include="Refactorings\ReplaceStringLiteralWithStringFormatRefactoring.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/source/Refactorings/Refactorings.xml
+++ b/source/Refactorings/Refactorings.xml
@@ -1187,4 +1187,9 @@
     </Syntaxes>
     <Scope>base list</Scope>
   </Refactoring>
+    <Refactoring Id="RR0180" Identifier="ReplaceStringLiteralWithStringFormat" Title="Replace string literal with string.Format invocation" ExtensionVersion="0.0.0">
+    <Syntaxes>
+      <Syntax>string literal</Syntax>
+    </Syntaxes>
+  </Refactoring>
 </Refactorings>

--- a/source/Refactorings/Refactorings/ReplaceStringLiteralWithStringFormatRefactoring.cs
+++ b/source/Refactorings/Refactorings/ReplaceStringLiteralWithStringFormatRefactoring.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Josef Pihrt. All rights reserved. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslynator.CSharp.Extensions;
+using Roslynator.Extensions;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Roslynator.CSharp.Refactorings
+{
+    internal static class ReplaceStringLiteralWithStringFormatRefactoring
+    {
+        private static readonly Regex _compositeFormatRegex = new Regex(@"{(\d+)(,-?\d+)?(:\w+)?}", RegexOptions.Compiled);
+
+        public static async Task ComputeRefactoringsAsync(RefactoringContext context, LiteralExpressionSyntax literalExpression)
+        {
+            if (literalExpression.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                SemanticModel semanticModel = await context.GetSemanticModelAsync().ConfigureAwait(false);
+
+                var parentInvocationExpression = literalExpression.FirstAncestor<InvocationExpressionSyntax>();
+
+                if (parentInvocationExpression != null)
+                {
+                    MethodInfo info = semanticModel.GetMethodInfo(parentInvocationExpression, context.CancellationToken);
+
+                    if (info.IsValid
+                        && info.HasName("Format")
+                        && info.IsContainingType(SpecialType.System_String))
+                    {
+                        // If the format string is already within a string.Format call then stop
+                        return;
+                    }
+                }
+
+                string text = literalExpression.Token.ValueText;
+
+                IEnumerable<int> formatItems = GetFormatItems(text);
+
+                if (formatItems.Any())
+                {
+                    var numberOfArgs = formatItems.First() + 1;
+
+                    context.RegisterRefactoring(
+                        "Replace string with string.Format invocation",
+                        cancellationToken =>
+                        {
+                            return ReplaceWithStringFormatAsync(
+                                context.Document,
+                                literalExpression,
+                                numberOfArgs,
+                                cancellationToken);
+                        });
+                }
+            }
+        }
+
+        private static IEnumerable<int> GetFormatItems(string text)
+        {
+            return _compositeFormatRegex.Matches(text).OfType<Match>()
+                .Select(m => int.Parse(m.Groups[1].Value))
+                .OrderByDescending(m => m)
+                .Distinct();
+        }
+
+        public static Task<Document> ReplaceWithStringFormatAsync(
+            Document document,
+            LiteralExpressionSyntax literalExpression,
+            int numberOfArgs,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var stringIdentifier = IdentifierName("string");
+            var format = IdentifierName("Format");
+            var memberAccess = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, stringIdentifier, format);
+            var argument = Argument(literalExpression);
+            var argumentSyntax = new List<ArgumentSyntax>();
+
+            argumentSyntax.Add(argument);
+
+            for (int i = 0; i < numberOfArgs; i++)
+            {
+                argumentSyntax.Add(Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal($"ARG{i}"))));
+            }
+
+            var argumentList = SeparatedList(argumentSyntax);
+
+            var stringFormatCall =
+                ExpressionStatement(
+                    InvocationExpression(
+                        memberAccess,
+                        ArgumentList(argumentList)));
+
+            return document.ReplaceNodeAsync(literalExpression, stringFormatCall.Expression, cancellationToken);
+        }
+    }
+}

--- a/source/Refactorings/Refactorings/StringLiteralExpressionRefactoring.cs
+++ b/source/Refactorings/Refactorings/StringLiteralExpressionRefactoring.cs
@@ -102,6 +102,9 @@ namespace Roslynator.CSharp.Refactorings
 
             if (context.IsRefactoringEnabled(RefactoringIdentifiers.ReplaceStringLiteralWithCharacterLiteral))
                 await ReplaceStringLiteralWithCharacterLiteralRefactoring.ComputeRefactoringAsync(context, literalExpression).ConfigureAwait(false);
+
+            if (context.IsRefactoringEnabled(RefactoringIdentifiers.ReplaceStringLiteralWithStringFormat))
+                await ReplaceStringLiteralWithStringFormatRefactoring.ComputeRefactoringsAsync(context, literalExpression).ConfigureAwait(false);
         }
 
         private static int GetStartIndex(RefactoringContext context, LiteralExpressionSyntax literalExpression)

--- a/source/VisualStudio.Core/RefactoringsOptionsPage.Generated.cs
+++ b/source/VisualStudio.Core/RefactoringsOptionsPage.Generated.cs
@@ -564,6 +564,7 @@ namespace Roslynator.VisualStudio
             refactorings.Add(new RefactoringModel(RefactoringIdentifiers.WrapInUsingStatement, "Wrap in using statement", IsEnabled(RefactoringIdentifiers.WrapInUsingStatement)));
             refactorings.Add(new RefactoringModel(RefactoringIdentifiers.AddTypeParameter, "Add type parameter", IsEnabled(RefactoringIdentifiers.AddTypeParameter)));
             refactorings.Add(new RefactoringModel(RefactoringIdentifiers.ImplementIEquatableOfT, "Implement IEquatable<T>", IsEnabled(RefactoringIdentifiers.ImplementIEquatableOfT)));
+            refactorings.Add(new RefactoringModel(RefactoringIdentifiers.ReplaceStringLiteralWithStringFormat, "Replace string literal with string.Format invocation", IsEnabled(RefactoringIdentifiers.ReplaceStringLiteralWithStringFormat)));
         }
 
         public void ApplyTo(RefactoringSettings settings)
@@ -716,6 +717,7 @@ namespace Roslynator.VisualStudio
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceStringContainsWithStringIndexOf, IsEnabled(RefactoringIdentifiers.ReplaceStringContainsWithStringIndexOf));
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceStringFormatWithInterpolatedString, IsEnabled(RefactoringIdentifiers.ReplaceStringFormatWithInterpolatedString));
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceStringLiteralWithCharacterLiteral, IsEnabled(RefactoringIdentifiers.ReplaceStringLiteralWithCharacterLiteral));
+            settings.SetRefactoring(RefactoringIdentifiers.ReplaceStringLiteralWithStringFormat, IsEnabled(RefactoringIdentifiers.ReplaceStringLiteralWithStringFormat));
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceSwitchWithIfElse, IsEnabled(RefactoringIdentifiers.ReplaceSwitchWithIfElse));
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceVerbatimStringLiteralWithRegularStringLiteral, IsEnabled(RefactoringIdentifiers.ReplaceVerbatimStringLiteralWithRegularStringLiteral));
             settings.SetRefactoring(RefactoringIdentifiers.ReplaceVerbatimStringLiteralWithRegularStringLiterals, IsEnabled(RefactoringIdentifiers.ReplaceVerbatimStringLiteralWithRegularStringLiterals));


### PR DESCRIPTION
I've recreated a refactoring I use quite often in ReSharper. In short, if it detects a string containing a composite format:

```
var myString = "Name = {0}, hours = {1:hh}";
```

then it will apply the refactoring to:

```
var myString = string.Format("Name = {0}, hours = {1:hh}", "ARG0", "ARG1");
```

It will take the highest indexed composite format in the string, and use that + 1 for the number of arguments. Unlike ReSharper, it does not allow you to tab through the arguments and replace them with variables, like with a code snippet. I'm not sure if that is possible in Roslyn.

I know that `string.Format` is a bit oldschool now as string interpolation is much better, but I wanted to learn a bit about Roslyn and was having a play around with your library. So if you think this is useful for the project, or have any questions, then let me know.