### PR TITLE
UseAnyMethodInsteadOfCountMethod with >= 1

### DIFF
--- a/source/Analyzers/Refactorings/UseInsteadOfCountMethod/ReplaceCountMethodRefactoring.cs
+++ b/source/Analyzers/Refactorings/UseInsteadOfCountMethod/ReplaceCountMethodRefactoring.cs
@@ -99,16 +99,28 @@ namespace Roslynator.CSharp.Refactorings.UseInsteadOfCountMethod
             {
                 var leftExpression = (LiteralExpressionSyntax)left;
 
-                if (leftExpression.IsZeroNumericLiteral()
-                     && binaryExpression.IsKind(
-                         SyntaxKind.EqualsExpression,
-                         SyntaxKind.LessThanExpression))
+                switch (binaryExpression.Kind())
                 {
-                    return true;
-                }
+                    case SyntaxKind.EqualsExpression:
+                    case SyntaxKind.LessThanExpression:
+                        {
+                            if (leftExpression.IsZeroNumericLiteral())
+                                return true;
 
-                return leftExpression.IsOneNumericLiteral()
-                    && binaryExpression.IsKind(SyntaxKind.LessThanOrEqualExpression);
+                            break;
+                        }
+                    case SyntaxKind.LessThanOrEqualExpression:
+                        {
+                            if (leftExpression.IsOneNumericLiteral())
+                                return true;
+
+                            break;
+                        }
+                    default:
+                        {
+                            return false;
+                        }
+                }
             }
             else
             {
@@ -118,16 +130,28 @@ namespace Roslynator.CSharp.Refactorings.UseInsteadOfCountMethod
                 {
                     var rightExpression = (LiteralExpressionSyntax)right;
 
-                    if (rightExpression.IsZeroNumericLiteral()
-                        && binaryExpression.IsKind(
-                            SyntaxKind.EqualsExpression,
-                            SyntaxKind.GreaterThanExpression))
+                    switch (binaryExpression.Kind())
                     {
-                        return true;
-                    }
+                        case SyntaxKind.EqualsExpression:
+                        case SyntaxKind.GreaterThanExpression:
+                            {
+                                if (rightExpression.IsZeroNumericLiteral())
+                                    return true;
 
-                    return rightExpression.IsOneNumericLiteral()
-                        && binaryExpression.IsKind(SyntaxKind.GreaterThanOrEqualExpression);
+                                break;
+                            }
+                        case SyntaxKind.GreaterThanOrEqualExpression:
+                            {
+                                if (rightExpression.IsOneNumericLiteral())
+                                    return true;
+
+                                break;
+                            }
+                        default:
+                            {
+                                return false;
+                            }
+                    }
                 }
             }
 

--- a/source/Analyzers/Refactorings/UseInsteadOfCountMethod/ReplaceCountMethodRefactoring.cs
+++ b/source/Analyzers/Refactorings/UseInsteadOfCountMethod/ReplaceCountMethodRefactoring.cs
@@ -45,7 +45,9 @@ namespace Roslynator.CSharp.Refactorings.UseInsteadOfCountMethod
                 else if (invocation.Parent?.IsKind(
                     SyntaxKind.EqualsExpression,
                     SyntaxKind.GreaterThanExpression,
-                    SyntaxKind.LessThanExpression) == true)
+                    SyntaxKind.GreaterThanOrEqualExpression,
+                    SyntaxKind.LessThanExpression,
+                    SyntaxKind.LessThanOrEqualExpression) == true)
                 {
                     var binaryExpression = (BinaryExpressionSyntax)invocation.Parent;
 
@@ -95,10 +97,18 @@ namespace Roslynator.CSharp.Refactorings.UseInsteadOfCountMethod
 
             if (left?.IsKind(SyntaxKind.NumericLiteralExpression) == true)
             {
-                return ((LiteralExpressionSyntax)left).IsZeroNumericLiteral()
-                    && binaryExpression.IsKind(
-                        SyntaxKind.EqualsExpression,
-                        SyntaxKind.LessThanExpression);
+                var leftExpression = (LiteralExpressionSyntax)left;
+
+                if (leftExpression.IsZeroNumericLiteral()
+                     && binaryExpression.IsKind(
+                         SyntaxKind.EqualsExpression,
+                         SyntaxKind.LessThanExpression))
+                {
+                    return true;
+                }
+
+                return leftExpression.IsOneNumericLiteral()
+                    && binaryExpression.IsKind(SyntaxKind.LessThanOrEqualExpression);
             }
             else
             {
@@ -106,10 +116,18 @@ namespace Roslynator.CSharp.Refactorings.UseInsteadOfCountMethod
 
                 if (right?.IsKind(SyntaxKind.NumericLiteralExpression) == true)
                 {
-                    return ((LiteralExpressionSyntax)right).IsZeroNumericLiteral()
+                    var rightExpression = (LiteralExpressionSyntax)right;
+
+                    if (rightExpression.IsZeroNumericLiteral()
                         && binaryExpression.IsKind(
                             SyntaxKind.EqualsExpression,
-                            SyntaxKind.GreaterThanExpression);
+                            SyntaxKind.GreaterThanExpression))
+                    {
+                        return true;
+                    }
+
+                    return rightExpression.IsOneNumericLiteral()
+                        && binaryExpression.IsKind(SyntaxKind.GreaterThanOrEqualExpression);
                 }
             }
 

--- a/source/Core/CSharp/Extensions/SyntaxExtensions.cs
+++ b/source/Core/CSharp/Extensions/SyntaxExtensions.cs
@@ -1035,7 +1035,7 @@ namespace Roslynator.CSharp
                 && string.Equals(literalExpression.Token.ValueText, "0", StringComparison.Ordinal);
         }
 
-        public static bool IsOneNumericLiteral(this LiteralExpressionSyntax literalExpression)
+        internal static bool IsOneNumericLiteral(this LiteralExpressionSyntax literalExpression)
         {
             if (literalExpression == null)
                 throw new ArgumentNullException(nameof(literalExpression));

--- a/source/Core/CSharp/Extensions/SyntaxExtensions.cs
+++ b/source/Core/CSharp/Extensions/SyntaxExtensions.cs
@@ -1035,6 +1035,15 @@ namespace Roslynator.CSharp
                 && string.Equals(literalExpression.Token.ValueText, "0", StringComparison.Ordinal);
         }
 
+        public static bool IsOneNumericLiteral(this LiteralExpressionSyntax literalExpression)
+        {
+            if (literalExpression == null)
+                throw new ArgumentNullException(nameof(literalExpression));
+
+            return literalExpression.IsKind(SyntaxKind.NumericLiteralExpression)
+                && string.Equals(literalExpression.Token.ValueText, "1", StringComparison.Ordinal);
+        }
+
         internal static string GetStringLiteralInnerText(this LiteralExpressionSyntax literalExpression)
         {
             if (literalExpression == null)

--- a/source/Test/AnalyzersTest/ReplaceCountMethodWithAnyMethod.cs
+++ b/source/Test/AnalyzersTest/ReplaceCountMethodWithAnyMethod.cs
@@ -18,6 +18,22 @@ namespace Roslynator.CSharp.Analyzers.Test
             if (sequence.Count() > 0)
             {
             }
+
+            if (sequence.Count() >= 1)
+            {
+            }
+
+            if (0 == sequence.Count())
+            {
+            }
+
+            if (0 < sequence.Count())
+            {
+            }
+
+            if (1 <= sequence.Count())
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for replacing `Count() >= 1` with `Any()`.

I've tested it by installing the generated vsix and visually inspect that they work as inspected in the RoslynatorTests solution.
Please let me know if I'm missing out on a more automatic test procedure.