### PR TITLE
Bitshifts on long and checks on unsigned

### DIFF
--- a/source/Analyzers/Refactorings/EnumMemberShouldDeclareExplicitValueRefactoring.cs
+++ b/source/Analyzers/Refactorings/EnumMemberShouldDeclareExplicitValueRefactoring.cs
@@ -188,9 +188,6 @@ namespace Roslynator.CSharp.Refactorings
                     value *= 2;
                 }
 
-                if (value < 0)
-                    return null;
-
                 if (Array.IndexOf(reservedValues, value) == -1)
                     i++;
             }
@@ -235,9 +232,6 @@ namespace Roslynator.CSharp.Refactorings
                 {
                     value *= 2;
                 }
-
-                if (value < 0)
-                    return null;
 
                 if (Array.IndexOf(reservedValues, value) == -1)
                     i++;
@@ -284,9 +278,6 @@ namespace Roslynator.CSharp.Refactorings
                     value *= 2;
                 }
 
-                if (value < 0)
-                    return null;
-
                 if (Array.IndexOf(reservedValues, value) == -1)
                     i++;
             }
@@ -331,9 +322,6 @@ namespace Roslynator.CSharp.Refactorings
                 {
                     value *= 2;
                 }
-
-                if (value < 0)
-                    return null;
 
                 if (Array.IndexOf(reservedValues, value) == -1)
                     i++;

--- a/source/Core/Utilities/FlagsUtility.cs
+++ b/source/Core/Utilities/FlagsUtility.cs
@@ -178,7 +178,7 @@ namespace Roslynator.Utilities
             if (reservedValues == null)
                 throw new ArgumentNullException(nameof(reservedValues));
 
-            byte[] values = reservedValues.Where(f => f >= 0 && IsZeroOrPowerOfTwo(f)).ToArray();
+            byte[] values = reservedValues.Where(IsZeroOrPowerOfTwo).ToArray();
 
             if (values.Length == 0)
                 return 0;
@@ -274,7 +274,7 @@ namespace Roslynator.Utilities
             if (reservedValues == null)
                 throw new ArgumentNullException(nameof(reservedValues));
 
-            ushort[] values = reservedValues.Where(f => f >= 0 && IsZeroOrPowerOfTwo(f)).ToArray();
+            ushort[] values = reservedValues.Where(IsZeroOrPowerOfTwo).ToArray();
 
             if (values.Length == 0)
                 return 0;
@@ -370,7 +370,7 @@ namespace Roslynator.Utilities
             if (reservedValues == null)
                 throw new ArgumentNullException(nameof(reservedValues));
 
-            uint[] values = reservedValues.Where(f => f >= 0 && IsZeroOrPowerOfTwo(f)).ToArray();
+            uint[] values = reservedValues.Where(IsZeroOrPowerOfTwo).ToArray();
 
             if (values.Length == 0)
                 return 0;
@@ -466,7 +466,7 @@ namespace Roslynator.Utilities
             if (reservedValues == null)
                 throw new ArgumentNullException(nameof(reservedValues));
 
-            ulong[] values = reservedValues.Where(f => f >= 0 && IsZeroOrPowerOfTwo(f)).ToArray();
+            ulong[] values = reservedValues.Where(IsZeroOrPowerOfTwo).ToArray();
 
             if (values.Length == 0)
                 return 0;
@@ -653,7 +653,7 @@ namespace Roslynator.Utilities
 
             for (int i = 0; i < maxValue; i++)
             {
-                var x = (long)(1 << i);
+                var x = 1L << i;
 
                 if (x > value)
                     yield break;
@@ -675,7 +675,7 @@ namespace Roslynator.Utilities
 
             for (int i = 0; i < maxValue; i++)
             {
-                var x = (ulong)(1 << i);
+                var x = 1UL << i;
 
                 if (x > value)
                     yield break;


### PR DESCRIPTION
`(long)(1 << i)` does not work as intended as `1` is implicitly an `int` and `int << i` overflows for `i >= 32`.

The removed checks are trivially true as an unsigned value is always `>= 0`.