### PR TITLE
Fix typo in RCS1223 docs

### DIFF
--- a/docs/analyzers/RCS1223.md
+++ b/docs/analyzers/RCS1223.md
@@ -22,7 +22,7 @@ public class Foo // RCS1223
 ### Code with Fix
 
 ```csharp
-DebuggerDisplay("{DebuggerDisplay,nq}")]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class Foo
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Analyzers/Analyzers.xml
+++ b/src/Analyzers/Analyzers.xml
@@ -4806,7 +4806,7 @@ if (y == null)
         <Before><![CDATA[public class Foo // RCS1223
 {
 }]]></Before>
-        <After><![CDATA[DebuggerDisplay("{DebuggerDisplay,nq}")]
+        <After><![CDATA[[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class Foo
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]


### PR DESCRIPTION
Adds a missing `[` to the code sample

I edited `Analyzers.xml` and then ran the following to regenerate the docs.
```
dotnet .\src\Tools\MetadataGenerator\bin\Debug\netcoreapp2.0\MetadataGenerator.dll src
```

I wasn't sure if anything else needed to be done.