### PR TITLE
Automatically copy global ruleset to target folder and open from there

### DIFF
--- a/src/VisualStudio.Common/GlobalSuppressionsOptionsPageControl.xaml
+++ b/src/VisualStudio.Common/GlobalSuppressionsOptionsPageControl.xaml
@@ -19,6 +19,7 @@
       <TextBlock TextWrapping="WrapWithOverflow">
       "Global Suppressions" feature has been deprecated in Roslynator 2019.
       For replacement, please see file "roslynator.ruleset" located in the extension directory.
+      Please note that Visual Studio must be restarted to activate changes in this file.
       </TextBlock>
       <Button Content="Open location" Click="OpenLocation_Click" />
     </WrapPanel>

--- a/src/VisualStudio.Common/GlobalSuppressionsOptionsPageControl.xaml.cs
+++ b/src/VisualStudio.Common/GlobalSuppressionsOptionsPageControl.xaml.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
-using Roslynator.CSharp;
 using System.ComponentModel;
 
 namespace Roslynator.VisualStudio
@@ -20,30 +19,27 @@ namespace Roslynator.VisualStudio
 
         private void OpenLocation_Click(object sender, RoutedEventArgs e)
         {
-            string appDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), 
+            string appDataFolderPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 @"JosefPihrt\Roslynator\VisualStudio\2019");
-            string ruleSetPath = Path.Combine(appDataFolder, "roslynator.ruleset");
+
+            string ruleSetPath = Path.Combine(appDataFolderPath, "roslynator.ruleset");
 
             if (!File.Exists(ruleSetPath))
             {
                 try
                 {
-                    string defaultRulesetFileName = GetDefaultRulesetFileName();
-                    if (defaultRulesetFileName != null && File.Exists(defaultRulesetFileName))
+                    string defaultRuleSetFileName = GetDefaultRulesetFileName();
+                    if (File.Exists(defaultRuleSetFileName))
                     {
-                        if (!Directory.Exists(appDataFolder))
-                        {
-                            Directory.CreateDirectory(appDataFolder);
-                        }
-                        File.Copy(defaultRulesetFileName, ruleSetPath);
+                        Directory.CreateDirectory(appDataFolderPath);
+
+                        File.Copy(defaultRuleSetFileName, ruleSetPath);
                     }
                 }
                 catch (Exception ex)
                 {
-                    if (ex is InvalidOperationException
-                        || ex is FileNotFoundException
-                        || ex is Win32Exception)
+                    if (ex is IOException || ex is UnauthorizedAccessException)
                     {
                         MessageBox.Show(ex.Message, null, MessageBoxButton.OK, MessageBoxImage.Error);
                     }
@@ -86,10 +82,9 @@ namespace Roslynator.VisualStudio
                 string assemblyDirPath = Path.GetDirectoryName(assemblyPath);
 
                 if (!string.IsNullOrEmpty(assemblyDirPath))
-                {
-                    return  Path.Combine(assemblyDirPath, "roslynator.ruleset");
-                }
+                    return Path.Combine(assemblyDirPath, "roslynator.ruleset");
             }
+
             return null;
         }
     }


### PR DESCRIPTION
This is a small improvement for the global ruleset file handling from #515. This will copy the default file to the AppData folder (if not yet there) and opens explorer in that location. So now users won't have to manually create the folder and copy the file around.

One possible further improvement would be to directly open the file on button click, with either notepad or VS ruleset editor. Not sure though if that is a good idea.