### PR TITLE
PrefixFieldIdentifierWithUnderscore  default

### DIFF
--- a/src/Common/RefactoringSettings.cs
+++ b/src/Common/RefactoringSettings.cs
@@ -6,11 +6,11 @@ namespace Roslynator
     {
         public static RefactoringSettings Current { get; } = new RefactoringSettings();
 
-        public bool PrefixFieldIdentifierWithUnderscore { get; set; } = true;
+        public bool PrefixFieldIdentifierWithUnderscore { get; set; }
 
         public override void Reset()
         {
-            PrefixFieldIdentifierWithUnderscore = true;
+            PrefixFieldIdentifierWithUnderscore = false;
             Disabled.Clear();
         }
     }

--- a/src/VisualStudio.Common/Configuration/Settings.cs
+++ b/src/VisualStudio.Common/Configuration/Settings.cs
@@ -21,7 +21,7 @@ namespace Roslynator.Configuration
         public Settings(
             IEnumerable<KeyValuePair<string, bool>> refactorings = null,
             IEnumerable<KeyValuePair<string, bool>> codeFixes = null,
-            bool prefixFieldIdentifierWithUnderscore = true)
+            bool prefixFieldIdentifierWithUnderscore = false)
         {
             Initialize(Refactorings, refactorings);
             Initialize(CodeFixes, codeFixes);

--- a/src/VisualStudio.Common/GeneralOptionsPage.cs
+++ b/src/VisualStudio.Common/GeneralOptionsPage.cs
@@ -17,7 +17,6 @@ namespace Roslynator.VisualStudio
 
         public GeneralOptionsPage()
         {
-            PrefixFieldIdentifierWithUnderscore = true;
             UseConfigFile = true;
         }
 


### PR DESCRIPTION
Set PrefixFieldIdentifierWithUnderscore default to `false` because this is the visual studio default.

**Rational:**
I know that there are two camps regarding the underscore prefix and I don`t wanna start arguing whether one is better than the other.

However, I think it makes more sense that roslynator respects the visual studio **default** in this case and not modifies the default.
Roslynator adds a ton of value by adding awesome refactorings and fixes and I think it is not the users expectation that it modifies its default CSharp code style. (At least it was not mine)

If one really likes the underscore prefix it is super easy to enable it, but I believe that roslynator should not change the default style in this regards.

