### PR TITLE
Improve Notify Property Changed (RR0083)

### DIFF
--- a/src/Core/Extensions/SymbolExtensions.cs
+++ b/src/Core/Extensions/SymbolExtensions.cs
@@ -1279,13 +1279,13 @@ namespace Roslynator
             Func<TSymbol, bool> predicate = null,
             bool includeBaseTypes = false) where TSymbol : ISymbol
         {
-            ImmutableArray<INamedTypeSymbol> members;
+            ImmutableArray<ISymbol> members;
 
             do
             {
                 members = (name != null)
-                    ? typeSymbol.GetTypeMembers(name)
-                    : typeSymbol.GetTypeMembers();
+                    ? typeSymbol.GetMembers(name)
+                    : typeSymbol.GetMembers();
 
                 TSymbol symbol = FindMemberImpl(members, predicate);
 

--- a/src/Core/MetadataNames.cs
+++ b/src/Core/MetadataNames.cs
@@ -35,6 +35,7 @@ namespace Roslynator
         public static readonly MetadataName System_ObsoleteAttribute = MetadataName.Parse("System.ObsoleteAttribute");
         public static readonly MetadataName System_Reflection = MetadataName.Parse("System.Reflection");
         public static readonly MetadataName System_Runtime_CompilerServices = MetadataName.Parse("System.Runtime.CompilerServices");
+        public static readonly MetadataName System_Runtime_CompilerServices_CallerMemberNameAttribute = MetadataName.Parse("System.Runtime.CompilerServices.CallerMemberNameAttribute");
         public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable");
         public static readonly MetadataName System_Runtime_CompilerServices_ConfiguredTaskAwaitable_T = MetadataName.Parse("System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1");
         public static readonly MetadataName System_Runtime_InteropServices_LayoutKind = MetadataName.Parse("System.Runtime.InteropServices.LayoutKind");

--- a/src/Tests/Refactorings.Tests/RR0083NotifyWhenPropertyChangeTests.cs
+++ b/src/Tests/Refactorings.Tests/RR0083NotifyWhenPropertyChangeTests.cs
@@ -170,5 +170,209 @@ class C : INotifyPropertyChanged
 }
 ", equivalenceKey: RefactoringId);
         }
+
+        [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.NotifyWhenPropertyChange)]
+        public async Task Test_GenerateDefaultOnPropertyChangedMethod()
+        {
+            await VerifyRefactoringAsync(@"
+using System.ComponentModel;
+
+namespace N
+{
+    class C : INotifyPropertyChanged
+    {
+        private string _value;
+
+        public string Value
+        {
+            get { return _value; }
+            [||]set { _value = value; }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}
+", @"
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace N
+{
+    class C : INotifyPropertyChanged
+    {
+        private string _value;
+
+        public string Value
+        {
+            get { return _value; }
+
+            set
+            {
+                if (_value != value)
+                {
+                    _value = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}
+", equivalenceKey: RefactoringId);
+        }
+
+        [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.NotifyWhenPropertyChange)]
+        public async Task Test_CantModifyWithoutAccessiblePropertyChangedOrNotifyMethod()
+        {
+            await VerifyNoRefactoringAsync(@"
+using System.ComponentModel;
+
+class C : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler PropertyChanged;
+}
+
+class D : C
+{
+    private string _value;
+
+    public string Value
+    {
+        get { return _value; }
+        [||]set { _value = value; }
+    }
+}
+", equivalenceKey: RefactoringId);
+        }
+
+        [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.NotifyWhenPropertyChange)]
+        public async Task Test_NamespacesAndOuterClassesShouldWork()
+        {
+            await VerifyRefactoringAsync(@"
+using System.ComponentModel;
+
+namespace L
+{
+    namespace N.M
+    {
+        class O
+        {
+            class C : INotifyPropertyChanged
+            {
+                private string _value;
+
+                public string Value
+                {
+                    get { return _value; }
+                    [||]set { _value = value; }
+                }
+
+                public event PropertyChangedEventHandler PropertyChanged;
+            }
+        }
+    }
+}
+", @"
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace L
+{
+    namespace N.M
+    {
+        class O
+        {
+            class C : INotifyPropertyChanged
+            {
+                private string _value;
+
+                public string Value
+                {
+                    get { return _value; }
+
+                    set
+                    {
+                        if (_value != value)
+                        {
+                            _value = value;
+                            OnPropertyChanged();
+                        }
+                    }
+                }
+
+                public event PropertyChangedEventHandler PropertyChanged;
+
+                protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+                {
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                }
+            }
+        }
+    }
+}
+", equivalenceKey: RefactoringId);
+        }
+
+        [Fact, Trait(Traits.Refactoring, RefactoringIdentifiers.NotifyWhenPropertyChange)]
+        public async Task Test_UsesCallerMemberNameWhenAvailable()
+        {
+            await VerifyRefactoringAsync(@"
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+class C : INotifyPropertyChanged
+{
+    private string _value;
+
+    public string Value
+    {
+        get { return _value; }
+        [||]set { _value = value; }
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+", @"
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+class C : INotifyPropertyChanged
+{
+    private string _value;
+
+    public string Value
+    {
+        get { return _value; }
+
+        set
+        {
+            if (_value != value)
+            {
+                _value = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+    {
+        PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+", equivalenceKey: RefactoringId);
+        }
     }
 }


### PR DESCRIPTION
* Generates OnNotifyPropertyChanged method when possible (PropertyChanged event must be declared in current class and not already exist)
* Uses CallerMemberName if available when calling existing or newly generated OnNotifyPropertyChange and RaiseEvent methods

I was working against the 2019 branch since that's what I have locally.

Also I fixed what I'm assuming was a bug in SymbolExtensions. I didn't see any code using this but it was weird that it used GetTypeMembers instead of GetMembers. I added a reference to this as well since it was useful for finding the Event property.