### PR TITLE
Update docs to enable analyzer in VSCode

### DIFF
--- a/docs/RoslynatorForVisualStudioCode.md
+++ b/docs/RoslynatorForVisualStudioCode.md
@@ -24,6 +24,8 @@
    * **Roslynator.CSharp.Workspaces.dll** (required)
    * **Roslynator.CSharp.CodeFixes.dll** (contains code fixes for compiler diagnostics)
    * **Roslynator.CSharp.Refactorings.dll** (contains refactorings)
+   * **Roslynator.CSharp.Analyzers.dll** (contains analyzer)
+   * **Roslynator.CSharp.Analyzers.CodeFixes.dll** (contains code fixes of analyzer)
 
 5. It may be necessary to [unblock dll files](https://blogs.msdn.microsoft.com/delay/p/unblockingdownloadedfile/).
 


### PR DESCRIPTION
I've verified that it works with omnisharp-vscode v1.20.0 and VSCode 1.36.1 :raised_hands: