### PR TITLE
Fix key duplication/handle camel case names

### DIFF
--- a/src/VisualStudioCode/package/package-lock.json
+++ b/src/VisualStudioCode/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roslynator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/VisualStudioCode/package/src/omnisharpSettings.ts
+++ b/src/VisualStudioCode/package/src/omnisharpSettings.ts
@@ -4,3 +4,9 @@ export interface OmnisharpSettings {
 		LocationPaths?: string[];
 	};
 }
+
+export enum OmnisharpSettingsKey {
+	RoslynExtensionsOptions = 'RoslynExtensionsOptions',
+	EnableAnalyzersSupport = 'EnableAnalyzersSupport',
+	LocationPaths = 'LocationPaths'
+}

--- a/src/VisualStudioCode/package/src/test/suite/extension.test.ts
+++ b/src/VisualStudioCode/package/src/test/suite/extension.test.ts
@@ -43,10 +43,10 @@ suite('Auto update omnisharp.json', () => {
 			RoslynExtensionsOptions: {
 				EnableAnalyzersSupport: true,
 				LocationPaths: [
-					"/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/common",
-					"/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/analyzers",
-					"/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/refactorings",
-					"/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/fixes"
+					'/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/common',
+					'/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/analyzers',
+					'/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/refactorings',
+					'/temp/home/.vscode/extensions/josefpihrt-vscode.roslynator-1.0.1/roslyn/fixes'
 				]
 			}
 		};
@@ -65,5 +65,37 @@ suite('Auto update omnisharp.json', () => {
 			p => p.includes('josefpihrt-vscode.roslynator-1.0.2')));
 		assert.ok(omnisharpSettings.RoslynExtensionsOptions?.LocationPaths?.every(
 			p => !p.includes('josefpihrt-vscode.roslynator-1.0.1')));
+	});
+
+	test('Handle camel cased properties', () => {
+		const oldOmnisharpSettings = {
+			RoslynExtensionsOptions: {
+				enableAnalyzersSupport: true,
+				locationPaths: [
+					'/path/to/custom/analyzers/'
+				]
+			}
+		};
+
+		fs.mkdirSync(omnisharpPath);
+		fs.writeJSONSync(omnisharpJsonPath, oldOmnisharpSettings);
+
+		roslynator.ensureConfigurationUpdated({
+			extensionDirectoryPath: path.join(extensionsPath, 'josefpihrt-vscode.roslynator-1.0.1'),
+			homeDirectoryPath: homePath
+		});
+
+		const omnisharpSettings = fs.readJSONSync(omnisharpJsonPath);
+
+		assert.strictEqual(omnisharpSettings.RoslynExtensionsOptions.LocationPaths, undefined);
+		assert.strictEqual(omnisharpSettings.RoslynExtensionsOptions.EnableAnalyzersSupport, undefined);
+
+		assert.ok(omnisharpSettings.RoslynExtensionsOptions.enableAnalyzersSupport);
+
+		assert.ok((omnisharpSettings.RoslynExtensionsOptions.locationPaths as string[])
+			.includes('/path/to/custom/analyzers/'));
+
+		assert.ok((omnisharpSettings.RoslynExtensionsOptions.locationPaths as string[])
+			.some(p => p.includes('josefpihrt-vscode.roslynator-1.0.1')));
 	});
 });


### PR DESCRIPTION
This should fix #629 - duplication of properties when non-pascal case name is used.

I go through existing properties with `Object.keys()` and look for a matching key regardless of its casing. If I can find one, I use it. If there isn't one, I default to using pascal case name.

Sorry again that it took so long 😓