### PR TITLE
Update RCS1166.md

### DIFF
--- a/docs/analyzers/RCS1166.md
+++ b/docs/analyzers/RCS1166.md
@@ -12,10 +12,15 @@
 
 ```csharp
 int x = 0;
+IntPtr y = IntPtr.Zero
 
 // ...
 
 if (x == null) // RCS1166
+{
+}
+
+if (y == null) // RCS1166
 {
 }
 ```
@@ -24,6 +29,10 @@ if (x == null) // RCS1166
 
 ```csharp
 if (x == 0)
+{
+}
+
+if (y == default)
 {
 }
 ```

--- a/src/Analyzers/Analyzers.xml
+++ b/src/Analyzers/Analyzers.xml
@@ -3285,13 +3285,22 @@ Unused parameter is not reported when its name consists of underscore(s).</Remar
     <Samples>
       <Sample>
         <Before><![CDATA[int x = 0;
+IntPtr y = IntPtr.Zero
 
 // ...
 
 if (x == null) // [|Id|]
 {
+}
+
+if (y == null) // [|Id|]
+{
 }]]></Before>
         <After><![CDATA[if (x == 0)
+{
+}
+
+if (y == default)
 {
 }]]></After>
       </Sample>


### PR DESCRIPTION
Add additional example for a non-numeric type in documentation for `RCS1166: Value type object is never equal to null`.