### PR TITLE
Introduce Markdownlint to project

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,15 @@
+{
+    "MD001": false,
+    "MD007": false,
+    "MD009": false,
+    "MD012": false,
+    "MD013": false,
+    "MD024": false,
+    "MD026": false,
+    "MD029": false,
+    "MD033": false,
+    "MD036": false,
+    "MD039": false,
+    "MD041": false,
+    "MD047": false
+}

--- a/src/Tests/Analyzers.Tests/Analyzers.Tests.csproj
+++ b/src/Tests/Analyzers.Tests/Analyzers.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/CSharp.Tests/CSharp.Tests.csproj
+++ b/src/Tests/CSharp.Tests/CSharp.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/CSharp.Workspaces.Tests/CSharp.Workspaces.Tests.csproj
+++ b/src/Tests/CSharp.Workspaces.Tests/CSharp.Workspaces.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/CodeAnalysis.Analyzers.Tests/CodeAnalysis.Analyzers.Tests.csproj
+++ b/src/Tests/CodeAnalysis.Analyzers.Tests/CodeAnalysis.Analyzers.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/CodeFixes.Tests/CodeFixes.Tests.csproj
+++ b/src/Tests/CodeFixes.Tests/CodeFixes.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Core.Tests/Core.Tests.csproj
+++ b/src/Tests/Core.Tests/Core.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Formatting.Analyzers.Tests/Formatting.Analyzers.Tests.csproj
+++ b/src/Tests/Formatting.Analyzers.Tests/Formatting.Analyzers.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Refactorings.Tests/Refactorings.Tests.csproj
+++ b/src/Tests/Refactorings.Tests/Refactorings.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Testing.Xunit/Testing.Xunit.csproj
+++ b/src/Tests/Testing.Xunit/Testing.Xunit.csproj
@@ -13,6 +13,7 @@
     <IsPackable>false</IsPackable>
     <Company></Company>
     <Description></Description>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Testing.Xunit/Testing.Xunit.csproj
+++ b/src/Tests/Testing.Xunit/Testing.Xunit.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/src/Tools/CodeGeneration/CodeGeneration.csproj
+++ b/src/Tools/CodeGeneration/CodeGeneration.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
-    <PackageReference Include="DotMarkdown" Version="0.1.0" />
+    <PackageReference Include="DotMarkdown" Version="0.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/Metadata/Metadata.csproj
+++ b/src/Tools/Metadata/Metadata.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tools/MetadataGenerator/MetadataGenerator.csproj
+++ b/src/Tools/MetadataGenerator/MetadataGenerator.csproj
@@ -13,7 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This introduces markdown lint which could be added to build after linting issues with API and generated docs ignored or resolved.  Might be useful to add to CI builds for project since it relies heavily on generated markdown for documentation.

```shell
npm install -g markdownlint-cli
markdownlint **/*.md
```

From <https://github.com/igorshubovych/markdownlint-cli> 

Current list of warnings from generated markdown, mostly minor.

```shell
docs/analyzers/RCS0053.md:13 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* fixes indentation of argumen..."]
docs/analyzers/RCS0053.md:17 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```cs"]
docs/analyzers/RCS0053.md:17 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:21 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
docs/analyzers/RCS0053.md:22 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```cs"]
docs/analyzers/RCS0053.md:22 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:27 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
docs/analyzers/RCS0053.md:28 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```cs"]
docs/analyzers/RCS0053.md:28 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:41 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:51 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:63 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:72 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:84 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:93 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:105 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0053.md:115 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS0054.md:12 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* fixes indentation of multi-l..."]
docs/analyzers/RCS0055.md:12 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* fixes indentation of multi-l..."]
docs/analyzers/RCS1213.md:12 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```editorconfig"]
docs/analyzers/RCS1227.md:22 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS1227.md:35 MD046/code-block-style Code block style [Expected: indented; Actual: fenced]
docs/analyzers/RCS9004.md:40 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `Microsoft.CodeAnalysis.Chil..."]
docs/analyzers/RCS9006.md:40 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `Microsoft.CodeAnalysis.Chil..."]
docs/analyzers/RCS9008.md:26 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "* `Microsoft.CodeAnalysis.Chil..."]
```
