### PR TITLE
Add Arm64 VS 2022 extension support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Arm64 VS 2022 extension support ([#990](https://github.com/JosefPihrt/Roslynator/pull/990)).
+
 ### Changed
 
 - Disable [RCS1080](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1080.md) by default ([#980](https://github.com/josefpihrt/roslynator/pull/980).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Arm64 VS 2022 extension support ([#990](https://github.com/JosefPihrt/Roslynator/pull/990)).
+- Add Arm64 VS 2022 extension support ([#990](https://github.com/JosefPihrt/Roslynator/pull/990) by @snickler).
 
 ### Changed
 

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -28,7 +28,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="17.0.32112.339" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5234" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/VisualStudio/source.extension.vsixmanifest
+++ b/src/VisualStudio/source.extension.vsixmanifest
@@ -15,12 +15,21 @@
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+	  <ProductArchitecture>arm64</ProductArchitecture>
+	</InstallationTarget>
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+	  <ProductArchitecture>arm64</ProductArchitecture>
+	</InstallationTarget>
+	  <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+	  <ProductArchitecture>arm64</ProductArchitecture>
+	</InstallationTarget>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />

--- a/src/VisualStudio/source.extension.vsixmanifest
+++ b/src/VisualStudio/source.extension.vsixmanifest
@@ -16,20 +16,20 @@
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-	  <ProductArchitecture>arm64</ProductArchitecture>
-	</InstallationTarget>
+        <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
     <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-	  <ProductArchitecture>arm64</ProductArchitecture>
-	</InstallationTarget>
-	  <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-	  <ProductArchitecture>arm64</ProductArchitecture>
-	</InstallationTarget>
+    <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />


### PR DESCRIPTION
Resolves #989 . 

This PR adds support for installing the Roslynator Visual Studio extension in Visual Studio 2022 17.4 Arm64. 

Screenshots:

![Screenshot_20221115_010546](https://user-images.githubusercontent.com/4016293/201841228-bfcb7553-826f-4f65-a4dd-9541c047db1b.png)

![Screenshot_20221115_010600](https://user-images.githubusercontent.com/4016293/201841308-edf52831-0581-47a0-b4f0-785d8d94bc19.png)

![Screenshot_20221115_010718](https://user-images.githubusercontent.com/4016293/201841347-cefc2149-6db1-4ac0-84f0-1ef20e01e416.png)
