### PR TITLE
Fix CS0164 CodeFixProvider

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not remove parameterless empty constructor in a struct with field initializers ([RCS1074](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1074.md)) ([#1021](https://github.com/josefpihrt/roslynator/pull/1021)).
 - Do not suggest to use generic event handler ([RCS1159](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1159.md)) ([#1022](https://github.com/josefpihrt/roslynator/pull/1022)).
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
+- Fix code fix for CS0164 ([#1031](https://github.com/JosefPihrt/Roslynator/pull/1031)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/src/CodeFixes/CSharp/CodeFixes/LabeledStatementCodeFixProvider.cs
+++ b/src/CodeFixes/CSharp/CodeFixes/LabeledStatementCodeFixProvider.cs
@@ -2,8 +2,10 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslynator.CodeFixes;
@@ -30,7 +32,15 @@ public sealed class LabeledStatementCodeFixProvider : CompilerDiagnosticCodeFixP
 
         if (!TryFindFirstAncestorOrSelf(root, context.Span, out LabeledStatementSyntax labeledStatement))
             return;
+        
+        var child = labeledStatement.ChildNodes().First();
+        
+        var codeAction = CodeAction.Create(
+            "Remove unused label",
+            ct => context.Document.ReplaceNodeAsync(labeledStatement, child, ct),
+            EquivalenceKey.Create(diagnostic));
+        
+        context.RegisterCodeFix(codeAction, diagnostic);
 
-        CodeFixRegistrator.RemoveStatement(context, diagnostic, labeledStatement, title: "Remove unused label");
     }
 }

--- a/src/CodeFixes/CSharp/CodeFixes/LabeledStatementCodeFixProvider.cs
+++ b/src/CodeFixes/CSharp/CodeFixes/LabeledStatementCodeFixProvider.cs
@@ -32,12 +32,10 @@ public sealed class LabeledStatementCodeFixProvider : CompilerDiagnosticCodeFixP
 
         if (!TryFindFirstAncestorOrSelf(root, context.Span, out LabeledStatementSyntax labeledStatement))
             return;
-        
-        var child = labeledStatement.ChildNodes().First();
-        
+                
         var codeAction = CodeAction.Create(
             "Remove unused label",
-            ct => context.Document.ReplaceNodeAsync(labeledStatement, child, ct),
+            ct => context.Document.ReplaceNodeAsync(labeledStatement, labeledStatement.Statement, ct),
             EquivalenceKey.Create(diagnostic));
         
         context.RegisterCodeFix(codeAction, diagnostic);

--- a/src/Tests/CodeFixes.Tests/CS0164LabelHasNotBeenReferencedTests.cs
+++ b/src/Tests/CodeFixes.Tests/CS0164LabelHasNotBeenReferencedTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Josef Pihrt and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Roslynator.Testing.CSharp;
+using Xunit;
+
+namespace Roslynator.CSharp.CodeFixes.Tests;
+
+public class CS0164LabelHasNotBeenReferencedTests : AbstractCSharpCompilerDiagnosticFixVerifier<LabeledStatementCodeFixProvider>
+{
+    public override string DiagnosticId { get; } = CompilerDiagnosticIdentifiers.CS0164_LabelHasNotBeenReferenced;
+
+    [Fact, Trait(Traits.CodeFix, CompilerDiagnosticIdentifiers.CS0164_LabelHasNotBeenReferenced)]
+    public async Task Test()
+    {
+        await VerifyFixAsync(@"
+using System;
+
+class C
+{
+    int M()
+    {
+    start:
+        return 1;
+    }
+}
+", @"
+using System;
+
+class C
+{
+    int M()
+    {
+        return 1;
+    }
+}
+", equivalenceKey: EquivalenceKey.Create(DiagnosticId));
+    }
+}


### PR DESCRIPTION
Previous behaviour would delete the child statement of the label. The correct behaviour is just to remove the label.