### PR TITLE
Fix for RemoveRedundantToStringCall(RCS1097) 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not remove parameterless empty constructor in a struct with field initializers ([RCS1074](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1074.md)) ([#1021](https://github.com/josefpihrt/roslynator/pull/1021)).
 - Do not suggest to use generic event handler ([RCS1159](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1159.md)) ([#1022](https://github.com/josefpihrt/roslynator/pull/1022)).
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
+- Fix ([RCS1097](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1097.md)) ([#1037](https://github.com/JosefPihrt/Roslynator/pull/1037)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/src/Analyzers/CSharp/Analysis/RemoveRedundantToStringCallAnalysis.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveRedundantToStringCallAnalysis.cs
@@ -58,6 +58,7 @@ internal static class RemoveRedundantToStringCallAnalysis
             INamedTypeSymbol containingType = methodSymbol.ContainingType;
 
             if (containingType?.IsReferenceType == true
+                && containingType.SpecialType != SpecialType.System_ValueType
                 && containingType.SpecialType != SpecialType.System_Enum)
             {
                 if (containingType.SpecialType == SpecialType.System_String)

--- a/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
@@ -105,7 +105,7 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveRedundantToStringCall)]
-    public async Task TestNoDiagnostic_int()
+    public async Task TestNoDiagnostic_Int()
     {
         await VerifyNoDiagnosticAsync(@"
 class C

--- a/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
@@ -105,7 +105,7 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveRedundantToStringCall)]
-    public async Task TestNoDiagnostic_ValueType()
+    public async Task TestNoDiagnostic_int()
     {
         await VerifyNoDiagnosticAsync(@"
 class C
@@ -114,6 +114,22 @@ class C
     {
         int i = 10;
         string s = $""'{i.ToString()}'"";
+    }
+}
+");
+    }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveRedundantToStringCall)]
+    public async Task TestNoDiagnostic_struct()
+    {
+        await VerifyNoDiagnosticAsync(@"
+struct S{}
+class C
+{
+    void M()
+    {
+        S s = new S();
+        string str = $""'{s.ToString()}'"";
     }
 }
 ");

--- a/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1097RemoveRedundantToStringCallTests.cs
@@ -120,7 +120,7 @@ class C
     }
     
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveRedundantToStringCall)]
-    public async Task TestNoDiagnostic_struct()
+    public async Task TestNoDiagnostic_Struct()
     {
         await VerifyNoDiagnosticAsync(@"
 struct S{}


### PR DESCRIPTION
Current behaviour:
- RCS1097 suggest removing ToString for structs which can lead to boxing.

It looks as if this was attempted to be prevented by using an IsReferenceType check at:
https://github.com/JosefPihrt/Roslynator/blob/3c6f1c1fc24b63aea6b0d82e64ec4e02d9ca39ad/src/Analyzers/CSharp/Analysis/RemoveRedundantToStringCallAnalysis.cs#L60

Unfortunately, this doesn't work for structs as they have type System.ValueType which is considered a reference type. See
https://learn.microsoft.com/en-us/dotnet/api/system.type.isvaluetype?redirectedfrom=MSDN&view=net-7.0#System_Type_IsValueType

Fix implemented just explicitly checks for `System_ValueType`.

Also added a test to catch future regressions.