### PR TITLE
Stop RCS1031, RCS1208 and RCS1211 from being applied if the local variables overlap.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not remove parameterless empty constructor in a struct with field initializers ([RCS1074](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1074.md)) ([#1021](https://github.com/josefpihrt/roslynator/pull/1021)).
 - Do not suggest to use generic event handler ([RCS1159](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1159.md)) ([#1022](https://github.com/josefpihrt/roslynator/pull/1022)).
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
+- Fix ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
+- Fix ([RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,9 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not remove parameterless empty constructor in a struct with field initializers ([RCS1074](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1074.md)) ([#1021](https://github.com/josefpihrt/roslynator/pull/1021)).
 - Do not suggest to use generic event handler ([RCS1159](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1159.md)) ([#1022](https://github.com/josefpihrt/roslynator/pull/1022)).
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
-- Fix ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
-- Fix ([RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
-- Fix ([RCS1208](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1208.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
+- Do not remove braces in the cases where there are overlapping local variables. ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md), [RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md), [RCS1208](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1208.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
 - Fix ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
 - Fix ([RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
+- Fix ([RCS1208](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1208.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryBracesInSwitchSectionAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryBracesInSwitchSectionAnalyzer.cs
@@ -107,28 +107,27 @@ public sealed class RemoveUnnecessaryBracesInSwitchSectionAnalyzer : BaseDiagnos
     
     private static bool LocalDeclaredVariablesOverlapWithAnyOtherSwitchSections(SwitchStatementSyntax switchStatement, BlockSyntax caseBlock, SemanticModel semanticModel)
     {
-        var caseVariablesDeclared = semanticModel.AnalyzeDataFlow(caseBlock)?
+        var caseVariablesDeclared = semanticModel.AnalyzeDataFlow(caseBlock)!
             .VariablesDeclared;
         
-        if (!caseVariablesDeclared.HasValue || caseVariablesDeclared.Value == ImmutableArray<ISymbol>.Empty)
+        if (caseVariablesDeclared.IsEmpty)
             return false;
 
-        var nameCaseDeclaredVariables = caseVariablesDeclared.Value
+        var nameCaseDeclaredVariables = caseVariablesDeclared
             .Select(s => s.Name)
             .ToImmutableHashSet();
 
         
-        // Now check if any of the other case statements under the same switch contain definitions for the same local variable. 
         return switchStatement.Sections.Any(section =>
         {
             if (section.Statements.SingleOrDefault(shouldThrow: false) is not BlockSyntax block || block == caseBlock)
                 return false;
 
-            var sectionVariablesDeclared = semanticModel.AnalyzeDataFlow(block)?.VariablesDeclared;
-            if (sectionVariablesDeclared is null || sectionVariablesDeclared.Value.IsEmpty)
+            var sectionVariablesDeclared = semanticModel.AnalyzeDataFlow(block)!.VariablesDeclared;
+            if (sectionVariablesDeclared.IsEmpty)
                 return false;
 
-            return sectionVariablesDeclared.Value.Any(s => nameCaseDeclaredVariables.Contains(s.Name));
+            return sectionVariablesDeclared.Any(s => nameCaseDeclaredVariables.Contains(s.Name));
 
         });
     }

--- a/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
@@ -73,22 +73,23 @@ public sealed class RemoveUnnecessaryElseAnalyzer : BaseDiagnosticAnalyzer
 
     private static bool LocalDeclaredVariablesOverlap(BlockSyntax elseBlock, BlockSyntax ifBlock, SemanticModel semanticModel)
     {        
-        var elseVariablesDeclared = semanticModel.AnalyzeDataFlow(elseBlock)?
+        var elseVariablesDeclared = semanticModel.AnalyzeDataFlow(elseBlock)!
             .VariablesDeclared;
         
-        if (!elseVariablesDeclared.HasValue || elseVariablesDeclared.Value == ImmutableArray<ISymbol>.Empty)
+        if (elseVariablesDeclared.IsEmpty)
             return false;
 
-        var ifVariablesDeclared = semanticModel.AnalyzeDataFlow(ifBlock)?
+        var ifVariablesDeclared = semanticModel.AnalyzeDataFlow(ifBlock)!
             .VariablesDeclared;
         
-        if (!ifVariablesDeclared.HasValue || ifVariablesDeclared.Value == ImmutableArray<ISymbol>.Empty)
+        if (ifVariablesDeclared.IsEmpty)
             return false;
-        var elseVariableNames = elseVariablesDeclared.Value
+
+        var elseVariableNames = elseVariablesDeclared
             .Select(s => s.Name)
             .ToImmutableHashSet();
         
-        return ifVariablesDeclared.Value
+        return ifVariablesDeclared
             .Any(s => elseVariableNames.Contains(s.Name));
     }
 }

--- a/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
@@ -88,8 +88,13 @@ public sealed class RemoveUnnecessaryElseAnalyzer : BaseDiagnosticAnalyzer
         var elseVariableNames = elseVariablesDeclared
             .Select(s => s.Name)
             .ToImmutableHashSet();
-        
-        return ifVariablesDeclared
-            .Any(s => elseVariableNames.Contains(s.Name));
+
+        foreach (var v in ifVariablesDeclared)
+        {
+            if (elseVariableNames.Contains(v.Name))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveUnnecessaryElseAnalyzer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Josef Pihrt and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -38,13 +40,13 @@ public sealed class RemoveUnnecessaryElseAnalyzer : BaseDiagnosticAnalyzer
         if (elseClause.ContainsDiagnostics)
             return;
 
-        if (!IsFixable(elseClause))
+        if (!IsFixable(elseClause, context.SemanticModel))
             return;
 
         DiagnosticHelpers.ReportDiagnostic(context, DiagnosticRules.RemoveUnnecessaryElse, elseClause.ElseKeyword);
     }
 
-    public static bool IsFixable(ElseClauseSyntax elseClause)
+    private static bool IsFixable(ElseClauseSyntax elseClause, SemanticModel semanticModel)
     {
         if (elseClause.Statement?.IsKind(SyntaxKind.IfStatement) != false)
             return false;
@@ -55,12 +57,31 @@ public sealed class RemoveUnnecessaryElseAnalyzer : BaseDiagnosticAnalyzer
         if (!ifStatement.IsTopmostIf())
             return false;
 
-        StatementSyntax statement = ifStatement.Statement;
+        StatementSyntax ifStatementStatement = ifStatement.Statement;
 
-        if (statement is BlockSyntax block)
-            statement = block.Statements.LastOrDefault();
+        if (ifStatementStatement is not BlockSyntax ifBlock)
+            return CSharpFacts.IsJumpStatement(ifStatementStatement.Kind());
+        
+        if (elseClause.Statement is BlockSyntax elseBlock && LocalDeclaredVariablesOverlap(elseBlock, ifBlock, semanticModel))
+            return false;
 
-        return statement is not null
-            && CSharpFacts.IsJumpStatement(statement.Kind());
+        var lastStatementInIf = ifBlock.Statements.LastOrDefault();
+
+        return lastStatementInIf is not null
+               && CSharpFacts.IsJumpStatement(lastStatementInIf.Kind());
+    }
+
+    private static bool LocalDeclaredVariablesOverlap(BlockSyntax elseBlock, BlockSyntax ifBlock, SemanticModel semanticModel)
+    {        
+        var elseDeclaredLocalVars = semanticModel
+            .LookupSymbols(elseBlock.CloseBraceToken.SpanStart-1)
+            .Where(s => s.Kind == SymbolKind.Local)
+            .Where(s => s.Locations.All(l => elseBlock.Span.Contains(l.SourceSpan)))
+            .Select(s => s.Name)
+            .ToImmutableHashSet();
+        
+        return semanticModel
+            .LookupSymbols(ifBlock.CloseBraceToken.SpanStart-1)
+            .Any(s => s.Kind == SymbolKind.Local && elseDeclaredLocalVars.Contains(s.Name));
     }
 }

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
@@ -294,15 +294,16 @@ internal static class ReduceIfNestingAnalysis
     {
         var ifVariablesDeclared = semanticModel.AnalyzeDataFlow(ifStatement)!
             .VariablesDeclared;
+        
         if (ifVariablesDeclared.IsEmpty)
             return false;
 
         var parentStatementDeclared = semanticModel.AnalyzeDataFlow(parent)!
             .VariablesDeclared;
         
-        // The Parent's declared variables will include those from the if and so we have to check for any symbols occuring twice.
+        // The parent's declared variables will include those from the if and so we have to check for any symbols occurring twice.
         return ifVariablesDeclared.Any(variable =>
-            parentStatementDeclared.Count(pVar => pVar.Name == variable.Name) > 1
+            parentStatementDeclared.Count(s => s.Name == variable.Name) > 1
         );
     }
 

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
@@ -73,9 +73,7 @@ internal static class ReduceIfNestingAnalysis
             }
 
             if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, switchSection, semanticModel))
-            {
                 return Fail(switchSection);
-            }
 
             return Success(jumpKind, switchSection);
         }
@@ -111,9 +109,7 @@ internal static class ReduceIfNestingAnalysis
             }
 
             if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, parent, semanticModel))
-            {
                 return Fail(parent);
-            }
 
             return Success(jumpKind, parent);
         }

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Josef Pihrt and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -71,6 +72,11 @@ internal static class ReduceIfNestingAnalysis
                 return Fail(switchSection);
             }
 
+            if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, switchSection, semanticModel))
+            {
+                return Fail(switchSection);
+            }
+
             return Success(jumpKind, switchSection);
         }
 
@@ -104,6 +110,11 @@ internal static class ReduceIfNestingAnalysis
                 return Fail(parent);
             }
 
+            if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, parent, semanticModel))
+            {
+                return Fail(parent);
+            }
+
             return Success(jumpKind, parent);
         }
 
@@ -126,6 +137,9 @@ internal static class ReduceIfNestingAnalysis
                     {
                         return Fail(parent);
                     }
+                    
+                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, parent, semanticModel))
+                        return Fail(parent);
 
                     return Success(jumpKind, parent);
                 }
@@ -135,12 +149,18 @@ internal static class ReduceIfNestingAnalysis
                 {
                     if (jumpKind == SyntaxKind.None)
                         return Fail(parent);
-
+                    
+                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, parent, semanticModel))
+                        return Fail(parent);
+                    
                     return Success(jumpKind, parent);
                 }
             case SyntaxKind.MethodDeclaration:
                 {
                     var methodDeclaration = (MethodDeclarationSyntax)parent;
+                    
+                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, methodDeclaration.Body, semanticModel))
+                        return Fail(parent);
 
                     if (jumpKind != SyntaxKind.None)
                         return Success(jumpKind, parent);
@@ -172,6 +192,9 @@ internal static class ReduceIfNestingAnalysis
             case SyntaxKind.LocalFunctionStatement:
                 {
                     var localFunction = (LocalFunctionStatementSyntax)parent;
+                    
+                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, localFunction.Body, semanticModel))
+                        return Fail(parent);
 
                     if (jumpKind != SyntaxKind.None)
                         return Success(jumpKind, parent);
@@ -203,6 +226,9 @@ internal static class ReduceIfNestingAnalysis
             case SyntaxKind.ParenthesizedLambdaExpression:
                 {
                     var anonymousFunction = (AnonymousFunctionExpressionSyntax)parent;
+
+                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, anonymousFunction.Block, semanticModel))
+                        return Fail(parent);
 
                     if (jumpKind != SyntaxKind.None)
                         return Success(jumpKind, parent);
@@ -258,6 +284,26 @@ internal static class ReduceIfNestingAnalysis
         }
 
         return Fail(parent);
+    }
+
+    private static bool LocallyDeclaredVariablesOverlapWithOuterScope(
+        IfStatementSyntax ifStatement,
+        SyntaxNode parent,
+        SemanticModel semanticModel
+    )
+    {
+        var ifVariablesDeclared = semanticModel.AnalyzeDataFlow(ifStatement)!
+            .VariablesDeclared;
+        if (ifVariablesDeclared.IsEmpty)
+            return false;
+
+        var parentStatementDeclared = semanticModel.AnalyzeDataFlow(parent)!
+            .VariablesDeclared;
+        
+        // The Parent's declared variables will include those from the if and so we have to check for any symbols occuring twice.
+        return ifVariablesDeclared.Any(variable =>
+            parentStatementDeclared.Count(pVar => pVar.Name == variable.Name) > 1
+        );
     }
 
     private static bool IsNestedFix(SyntaxNode node, SemanticModel semanticModel, ReduceIfNestingOptions options, CancellationToken cancellationToken)

--- a/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
@@ -186,4 +186,33 @@ class C
 }
 ");
     }
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
+    public async Task TestNoDiagnostic_WhenOverlappingLocalVariableDeclaration()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+
+class C
+{
+    void M()
+    {
+        string s = null;
+
+        switch (s)
+        {
+            case """":
+                {
+                    var x = 1;
+                    break;
+                }
+            default:
+                {
+                    var x = 1;
+                    break;
+                }
+        }
+    }
+}
+");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
@@ -141,6 +141,57 @@ class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
+    public async Task Test_WithLocalVariablesThatDoNotOverlap()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+
+class C
+{
+    void M()
+    {
+        string s = null;
+
+        switch (s)
+        {
+            case """":
+                [|{|]
+                    var x = 1;
+                    break;
+                }
+            default:
+                [|{|]
+                    var y = 1;
+                    break;
+                }
+        }
+    }
+}
+",@"
+using System;
+
+class C
+{
+    void M()
+    {
+        string s = null;
+
+        switch (s)
+        {
+            case """":
+                var x = 1;
+                break;
+
+            default:
+                var y = 1;
+                break;
+        }
+    }
+}
+");
+    }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
     public async Task TestNoDiagnostic_SectionWithoutBlock()
@@ -186,6 +237,7 @@ class C
 }
 ");
     }
+    
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
     public async Task TestNoDiagnostic_WhenOverlappingLocalVariableDeclaration()
     {

--- a/src/Tests/Analyzers.Tests/RCS1208ReduceIfNestingTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1208ReduceIfNestingTests.cs
@@ -49,4 +49,33 @@ class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task TestNoDiagnostic_OverlappingLocalVariables()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void M(bool p, bool q)
+    {
+        if (p)
+        {
+            var x = 1;
+            M2();
+        }
+
+        if(q)
+        {
+            var x = 2;
+            M2();
+        }
+
+    }
+
+    void M2()
+    {
+    }
+}
+");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1211RemoveUnnecessaryElseTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1211RemoveUnnecessaryElseTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Josef Pihrt and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslynator.CSharp.CodeFixes;
+using Roslynator.Testing.CSharp;
+using Xunit;
+
+namespace Roslynator.CSharp.Analysis.Tests;
+
+public class RCS1211RemoveUnnecessaryElseTests : AbstractCSharpDiagnosticVerifier<RemoveUnnecessaryElseAnalyzer, RemoveUnnecessaryElseCodeFixProvider>
+{
+    public override DiagnosticDescriptor Descriptor { get; } = DiagnosticRules.RemoveUnnecessaryElse;
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryElse)]
+    public async Task Test_UnnecessaryElse_Removed()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    int M(bool flag)
+    {
+        if(flag)
+        {
+            return 1;
+        }
+        [|else|]
+        {
+            return 0;
+        }
+    }
+}
+", @"
+class C
+{
+    int M(bool flag)
+    {
+        if(flag)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+}
+");
+    }
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryElse)]
+    public async Task TestNoDiagnostic_OverlappingLocalVariables()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    int M(bool flag)
+    {
+        if(flag)
+        {
+            var z = 1;
+            return z;
+        }
+        else
+        {
+            var z = 0;
+            return z;
+        }
+    }
+}
+");
+    }
+
+}


### PR DESCRIPTION
For cases, where the same local variable is declared inside the if and else blocks e.g.
```
if (flag)
{
    var x  = 1;
    return x;
}
else 
{
    var x = 0;
    return x;
}
```
The diagnostic RCS1211 Should not be raised. 

Removing the else block would cause a compiler error "A local variable named 'x' cannot be declared in this scope because it would give a different meaning to 'x', which is already used in a parent or current scope to denote something else".

The same thing is true for switch case brackets (RCS1031).