### PR TITLE
Fix handling of records in RCS1223

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not remove parameterless empty constructor in a struct with field initializers ([RCS1074](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1074.md)) ([#1021](https://github.com/josefpihrt/roslynator/pull/1021)).
 - Do not suggest to use generic event handler ([RCS1159](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1159.md)) ([#1022](https://github.com/josefpihrt/roslynator/pull/1022)).
 - Fix ([RCS1077](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1077.md)) ([#1023](https://github.com/josefpihrt/roslynator/pull/1023)).
+- Fix ([RCS1223](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1223.md)) ([#1051](https://github.com/JosefPihrt/Roslynator/pull/1051)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/src/Analyzers/CSharp/Analysis/MarkTypeWithDebuggerDisplayAttributeAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/MarkTypeWithDebuggerDisplayAttributeAnalyzer.cs
@@ -73,22 +73,12 @@ public sealed class MarkTypeWithDebuggerDisplayAttributeAnalyzer : BaseDiagnosti
 
         if (typeSymbol.OriginalDefinition.HasAttribute(debuggerDisplayAttributeSymbol, includeBaseTypes: true))
             return;
-
-        SyntaxToken identifier;
-
-        if (typeKind == TypeKind.Class)
-        {
-            var classDeclaration = (ClassDeclarationSyntax)typeSymbol.GetSyntax(context.CancellationToken);
-
-            identifier = classDeclaration.Identifier;
-        }
-        else
-        {
-            var structDeclaration = (StructDeclarationSyntax)typeSymbol.GetSyntax(context.CancellationToken);
-
-            identifier = structDeclaration.Identifier;
-        }
-
+        
+        if(typeSymbol.GetSyntax(context.CancellationToken) is not TypeDeclarationSyntax typeDeclaration)
+            return;
+        
+        var identifier = typeDeclaration.Identifier;
+        
         DiagnosticHelpers.ReportDiagnostic(context, DiagnosticRules.MarkTypeWithDebuggerDisplayAttribute, identifier, identifier.ValueText);
     }
 }

--- a/src/Tests/Analyzers.Tests/RCS1223MarkTypeWithDebuggerDisplayAttributeTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1223MarkTypeWithDebuggerDisplayAttributeTests.cs
@@ -287,4 +287,32 @@ public abstract class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MarkTypeWithDebuggerDisplayAttribute)]
+    public async Task Test_PublicRecord()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Diagnostics;
+
+public record [|R|]
+{
+}
+", @"
+using System.Diagnostics;
+
+[DebuggerDisplay(""{DebuggerDisplay,nq}"")]
+public record R
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay
+    {
+        get
+        {
+            return ToString();
+        }
+    }
+}
+");
+    }
+
 }

--- a/src/Workspaces.Common/CSharp/Refactorings/MarkTypeWithDebuggerDisplayAttributeRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/MarkTypeWithDebuggerDisplayAttributeRefactoring.cs
@@ -29,18 +29,7 @@ internal static class MarkTypeWithDebuggerDisplayAttributeRefactoring
 
         PropertyDeclarationSyntax propertyDeclaration = DebuggerDisplayPropertyDeclaration(propertyName, InvocationExpression(IdentifierName("ToString")));
 
-        TypeDeclarationSyntax newTypeDeclaration;
-
-        if (typeDeclaration is ClassDeclarationSyntax classDeclaration)
-        {
-            newTypeDeclaration = SyntaxRefactorings.AddAttributeLists(classDeclaration, keepDocumentationCommentOnTop: true, attributeList);
-        }
-        else
-        {
-            var structDeclaration = (StructDeclarationSyntax)typeDeclaration;
-
-            newTypeDeclaration = SyntaxRefactorings.AddAttributeLists(structDeclaration, keepDocumentationCommentOnTop: true, attributeList);
-        }
+        TypeDeclarationSyntax newTypeDeclaration = SyntaxRefactorings.AddAttributeLists(typeDeclaration, keepDocumentationCommentOnTop: true, attributeList);
 
         newTypeDeclaration = MemberDeclarationInserter.Default.Insert(newTypeDeclaration, propertyDeclaration);
 


### PR DESCRIPTION
Currently, this analyzer will throw the following error when it comes across a record:
`System.Exception : Analyzer execution threw exception Analyzer 'Roslynator.CSharp.Analysis.MarkTypeWithDebuggerDisplayAttributeAnalyzer' threw an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.RecordDeclarationSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax'.'.
`
This shows up as an AD0001 Diagnostic.

Casting Instead to TypeDeclerationSyntax means that we can also handle records correctly. There is no behaviour change for either Struct or Class if we cast to TypeDeclerationSyntax.
