### PR TITLE
Fix/RCS1031 and RCS1208

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ([RCS1206](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1206.md)) ([#1049](https://github.com/JosefPihrt/Roslynator/pull/1049)).
 - Prevent possible recursion in ([RCS1235](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1235.md)) ([#1054](https://github.com/JosefPihrt/Roslynator/pull/1054)).
 - Fix ([RCS1223](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1223.md)) ([#1051](https://github.com/JosefPihrt/Roslynator/pull/1051)).
-- Do not remove braces in the cases where there are overlapping local variables. ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md), [RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md), [RCS1208](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1208.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039)).
+- Do not remove braces in the cases where there are overlapping local variables. ([RCS1031](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1013.md), [RCS1211](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1211.md), [RCS1208](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1208.md)) ([#1039](https://github.com/JosefPihrt/Roslynator/pull/1039),[#1058](https://github.com/JosefPihrt/Roslynator/pull/1058)).
 
 ## [4.2.0] - 2022-11-27
 

--- a/src/CSharp/PattenMatchingVariableDeclarationHelper.cs
+++ b/src/CSharp/PattenMatchingVariableDeclarationHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Roslynator.CSharp.Analysis;
+
+public static class PattenMatchingVariableDeclarationHelper
+{
+    public static IEnumerable<string> GetVariablesDeclared(PatternSyntax patternSyntax)
+    {
+        switch (patternSyntax)
+        {
+            case DeclarationPatternSyntax { Designation: var variableDesignationSyntax}:
+                return GetVariablesDeclared(variableDesignationSyntax);
+            case RecursivePatternSyntax { PositionalPatternClause: var positionalPatternClause, PropertyPatternClause: var propertyPatternClause, Designation: var designation }:
+                 var designationVars = designation != null ? GetVariablesDeclared(designation):Array.Empty<string>();
+                 var propertyVars = propertyPatternClause?.Subpatterns.SelectMany(p=>GetVariablesDeclared(p.Pattern)) ?? Array.Empty<string>();
+                 var positionalVars = positionalPatternClause?.Subpatterns.SelectMany(p => GetVariablesDeclared(p.Pattern)) ?? Array.Empty<string>();
+                 return designationVars.Concat(propertyVars).Concat(positionalVars);
+            case VarPatternSyntax { Designation: var variableDesignationSyntax}:
+                return GetVariablesDeclared(variableDesignationSyntax);
+            case BinaryPatternSyntax binaryPatternSyntax:
+                return GetVariablesDeclared(binaryPatternSyntax.Left)
+                    .Concat(GetVariablesDeclared(binaryPatternSyntax.Right));
+            case ParenthesizedPatternSyntax parenthesizedPatternSyntax:
+                return GetVariablesDeclared(parenthesizedPatternSyntax.Pattern);
+        }
+        return Array.Empty<string>();
+    }
+    
+    public static IEnumerable<string> GetVariablesDeclared(VariableDesignationSyntax? designationSyntax)
+    {
+        switch (designationSyntax)
+        {
+            case SingleVariableDesignationSyntax singleVariableDesignationSyntax:
+                yield return singleVariableDesignationSyntax.Identifier.ValueText;
+                break;
+            case ParenthesizedVariableDesignationSyntax parenthesizedVariableDesignationSyntax:
+                foreach (var variable in parenthesizedVariableDesignationSyntax.Variables)
+                {
+                    foreach (var v in GetVariablesDeclared(variable))
+                    {
+                        yield return v;
+                    }
+                }
+                break;
+            case DiscardDesignationSyntax _:
+                yield break;
+        }
+    }
+
+}

--- a/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
+++ b/src/Common/CSharp/Analysis/ReduceIfNesting/ReduceIfNestingAnalysis.cs
@@ -135,9 +135,6 @@ internal static class ReduceIfNestingAnalysis
                         return Fail(parent);
                     }
                     
-                    if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, parent, semanticModel))
-                        return Fail(parent);
-
                     var parentBody = parentKind switch
                     {
                         SyntaxKind.ConstructorDeclaration => ((ConstructorDeclarationSyntax)parent).Body,
@@ -155,7 +152,8 @@ internal static class ReduceIfNestingAnalysis
                 }
             case SyntaxKind.OperatorDeclaration:
             case SyntaxKind.ConversionOperatorDeclaration:
-                {
+            case SyntaxKind.GetAccessorDeclaration:
+            {
                     if (jumpKind == SyntaxKind.None)
                         return Fail(parent);
                     
@@ -163,6 +161,7 @@ internal static class ReduceIfNestingAnalysis
                     {
                         SyntaxKind.OperatorDeclaration => ((OperatorDeclarationSyntax)parent).Body,
                         SyntaxKind.ConversionOperatorDeclaration => ((ConversionOperatorDeclarationSyntax)parent).Body,
+                        SyntaxKind.GetAccessorDeclaration => ((AccessorDeclarationSyntax)parent).Body,
                         _ => throw new NotImplementedException()
                     };
 
@@ -171,17 +170,6 @@ internal static class ReduceIfNestingAnalysis
                     
                     return Success(jumpKind, parent);
                 }
-            case SyntaxKind.GetAccessorDeclaration:
-            { 
-                var accessorDeclaration = (AccessorDeclarationSyntax)parent;
-                if (jumpKind == SyntaxKind.None)
-                    return Fail(parent);
-                    
-                if (LocallyDeclaredVariablesOverlapWithOuterScope(ifStatement, accessorDeclaration.Body, semanticModel))
-                    return Fail(parent);
-                    
-                return Success(jumpKind, parent);
-            }
             case SyntaxKind.MethodDeclaration:
                 {
                     var methodDeclaration = (MethodDeclarationSyntax)parent;

--- a/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1031RemoveUnnecessaryBracesInSwitchSectionTests.cs
@@ -237,7 +237,6 @@ class C
 }
 ");
     }
-    
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
     public async Task TestNoDiagnostic_WhenOverlappingLocalVariableDeclaration()
     {
@@ -267,4 +266,66 @@ class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
+    public async Task TestNoDiagnostic_WhenOverlappingLocalVariableWithPatternMatchDeclaration()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+
+class C
+{
+    void M()
+    {
+        object o = null;
+
+        switch (o)
+        {
+            case string s:
+                var x = 1;
+                break;
+            default:
+                {
+                    var s = 1;
+                    break;
+                }
+        }
+    }
 }
+");
+    }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.RemoveUnnecessaryBracesInSwitchSection)]
+    public async Task TestNoDiagnostic_WhenOverlappingLocalVariableWithRecursivePatternMatchDeclaration()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+
+class C
+{
+    class Wrapper
+    {
+        public string S;
+    }
+    void M()
+    {
+        object o = null;
+
+        switch (o)
+        {
+            case Wrapper { S: var s }:
+                var x = 1;
+                break;
+            default:
+                {
+                    var s = 1;
+                    break;
+                }
+        }
+    }
+}
+");
+    }
+}
+
+

--- a/src/Tests/Analyzers.Tests/RCS1208ReduceIfNestingTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1208ReduceIfNestingTests.cs
@@ -13,7 +13,90 @@ public class RCS1208ReduceIfNestingTests : AbstractCSharpDiagnosticVerifier<Redu
     public override DiagnosticDescriptor Descriptor { get; } = DiagnosticRules.ReduceIfNesting;
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
-    public async Task Test()
+    public async Task Test_WhenParentIsConstructor()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    C(bool p)
+    {
+        [|if|] (p)
+        {
+            M2();
+        }
+    }
+
+    void M2()
+    {
+    }
+}
+", @"
+class C
+{
+    C(bool p)
+    {
+        if (!p)
+        {
+            return;
+        }
+
+        M2();
+    }
+
+    void M2()
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task Test_WhenParentIsGetAccessor()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    static bool b=false;
+    public static bool s {
+        get {
+            [|if|] (b) {
+                return M2();
+            }
+            return false;
+        }  
+    }
+
+    static bool M2()
+    {
+        return true;
+    }
+}
+", @"
+class C
+{
+    static bool b=false;
+    public static bool s {
+        get
+        {
+            if (!b)
+            {
+                return false;
+            }
+
+            return M2();
+        }
+    }
+
+    static bool M2()
+    {
+        return true;
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task Test_WhenParentIsMethod()
     {
         await VerifyDiagnosticAndFixAsync(@"
 class C
@@ -41,6 +124,141 @@ class C
         }
 
         M2();
+    }
+
+    void M2()
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task Test_WhenParentIsConversionOperator()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    static bool b=false;
+    public static implicit operator bool(C c)
+    {
+        [|if|] (b)
+        {
+            return M2();
+        }
+        return false;
+    }
+
+    static bool M2()
+    {
+        return true;
+    }
+}
+", @"
+class C
+{
+    static bool b=false;
+    public static implicit operator bool(C c)
+    {
+        if (!b)
+        {
+            return false;
+        }
+
+        return M2();
+    }
+
+    static bool M2()
+    {
+        return true;
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task Test_WhenParentIsLocalFunction()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(bool p)
+    {
+        void M3()
+        {
+            [|if|] (p)
+            {
+                M2();
+            }
+
+        }
+        M3();
+    }
+
+    void M2()
+    {
+    }
+}
+", @"
+class C
+{
+    void M(bool p)
+    {
+        void M3()
+        {
+            if (!p)
+            {
+                return;
+            }
+
+            M2();
+        }
+        M3();
+    }
+
+    void M2()
+    {
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ReduceIfNesting)]
+    public async Task Test_WhenParentIsLambda()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    void M(bool p)
+    {
+        var f = () => 
+        {
+            [|if|] (p)
+            {
+                M2();
+            }
+        };
+    }
+
+    void M2()
+    {
+    }
+}
+", @"
+class C
+{
+    void M(bool p)
+    {
+        var f = () =>
+            {
+                if (!p)
+                {
+                    return;
+                }
+
+                M2();
+            }
+;
     }
 
     void M2()

--- a/src/Tests/CSharp.Tests/PatternMatchingVariableDeclarationHelperTests.cs
+++ b/src/Tests/CSharp.Tests/PatternMatchingVariableDeclarationHelperTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslynator.CSharp.Analysis;
+using Xunit;
+
+namespace Roslynator.Testing.CSharp;
+
+public class PatternMatchingVariableDeclarationHelperTests
+{
+    [Fact]
+    public void SingleVariableDesignation()
+    {
+        VariableDesignationSyntax designationSyntax = SyntaxFactory.SingleVariableDesignation(
+            SyntaxFactory.Identifier("x")
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(designationSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True("x"== variables.First());
+    }
+    
+    [Fact]
+    public void ParenthesizedVariableDesignation()
+    {
+        VariableDesignationSyntax designationSyntax = SyntaxFactory.ParenthesizedVariableDesignation(
+            SyntaxFactory.SeparatedList(new List<VariableDesignationSyntax>
+            {
+                SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x")),
+                SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("y"))
+            })
+        );
+
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(designationSyntax);
+        Assert.True(2 == variables.Count());
+        Assert.True(variables.Contains("x"));
+        Assert.True(variables.Contains("y"));
+    }
+
+    [Fact]
+    public void DiscardDesignation()
+    {
+        VariableDesignationSyntax designationSyntax = SyntaxFactory.DiscardDesignation();
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(designationSyntax);
+        Assert.True(!variables.Any());
+    }
+    
+    [Fact]
+    public void NullTest()
+    {
+        VariableDesignationSyntax designationSyntax = null;
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(designationSyntax);
+        Assert.True(!variables.Any());
+
+    }
+    
+    [Fact]
+    public void DeclarationPattern()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.DeclarationPattern(
+            SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
+            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x"))
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True("x"== variables.First());
+    }
+    
+    [Fact]
+    public void RecursivePattern_WithPositional()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.RecursivePattern(
+            SyntaxFactory.IdentifierName("TypeA"),
+            positionalPatternClause: SyntaxFactory.PositionalPatternClause(
+                SyntaxFactory.SeparatedList(new List<SubpatternSyntax>
+                {
+                    SyntaxFactory.Subpattern(
+                        SyntaxFactory.DeclarationPattern(
+                            SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
+                            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("p1"))
+                        )
+                        ),
+                    SyntaxFactory.Subpattern(
+                        SyntaxFactory.DeclarationPattern(
+                            SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
+                            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("p2"))
+                        )
+                    )
+                })
+            ),
+            propertyPatternClause: default,
+            designation: default
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(2==variables.Count());
+        Assert.True(variables.Contains("p1"));
+        Assert.True(variables.Contains("p2"));
+    }
+    
+    [Fact]
+    public void RecursivePattern_WithProperty()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.RecursivePattern(
+            SyntaxFactory.IdentifierName("TypeA"),
+            positionalPatternClause: default,
+            propertyPatternClause: SyntaxFactory.PropertyPatternClause(
+                SyntaxFactory.SeparatedList(new List<SubpatternSyntax>
+                {
+                    SyntaxFactory.Subpattern(
+                        SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("PropertyName")),
+                        SyntaxFactory.VarPattern(
+                            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x"))
+                        )
+                    ),
+                })
+            ),
+            designation: default
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True(variables.Contains("x"));
+    }
+    
+    [Fact]
+    public void RecursivePattern_WithDesignation()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.RecursivePattern(
+            SyntaxFactory.IdentifierName("TypeA"),
+            positionalPatternClause: default,
+            propertyPatternClause: SyntaxFactory.PropertyPatternClause(
+                SyntaxFactory.SeparatedList(new List<SubpatternSyntax>
+                {
+                    SyntaxFactory.Subpattern(
+                        SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("PropertyName")),
+                        SyntaxFactory.ConstantPattern(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(42)))
+                    ),
+                })
+            ),
+           designation: SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x"))
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True(variables.Contains("x"));
+    
+    }
+    
+    [Fact]
+    public void VarPattern()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.VarPattern(
+            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x"))
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True("x"==variables.First());
+
+    }
+    
+    [Fact]
+    public void BinaryPattern()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.BinaryPattern(
+            SyntaxKind.AndPattern,
+            SyntaxFactory.ConstantPattern(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(42))),
+            SyntaxFactory.ConstantPattern(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(99)))
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(!variables.Any());
+    }
+
+    [Fact]
+    public void ParenthesizedPattern()
+    {
+        PatternSyntax patternSyntax = SyntaxFactory.ParenthesizedPattern(
+            SyntaxFactory.VarPattern(
+                SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier("x"))
+            )
+        );
+        var variables = PattenMatchingVariableDeclarationHelper.GetVariablesDeclared(patternSyntax);
+        Assert.True(1==variables.Count());
+        Assert.True("x"==variables.First());
+    }
+
+}


### PR DESCRIPTION
This PR extends the local variable check from https://github.com/JosefPihrt/Roslynator/pull/1039 to also check variables assigned during pattern matching for RCS1031.

Slightly embarrassingly, I didn't check all the ReduceIfNestingAnalysis code paths in https://github.com/JosefPihrt/Roslynator/pull/1039 and so I didn't realise that the AnalyzeDataFlow can only handle an argument of type ExpressionSyntax or StatementSyntax. If you pass it anything else then it will throw a run time error. This PR fixes this issue and adds a number of new tests to enforce.

It is currently not trivial to test the Loop / Switch sections of ReduceIfNestingAnalysis.AnalyzeCore via the analyzer as it passes through `ReduceIfNestingOptions.None`. However, I manually removed the guard clause on lines 63 and 90 and confirmed that it was working correctly. 