### PR TITLE
Fix RCS1009's handling of discard designations.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [CLI] Analyze command does not create the XML output file and returns incorrect exit code when only compiler diagnostics are reported ([#1056](https://github.com/JosefPihrt/Roslynator/pull/1056) by @PeterKaszab).
 - [CLI] Fix exit code when multiple projects are processed ([#1061](https://github.com/JosefPihrt/Roslynator/pull/1061) by @PeterKaszab).
 - Fix code fix for CS0164 ([#1031](https://github.com/JosefPihrt/Roslynator/pull/1031)).
+- Fix RCS1009 to handles discard designations ([#1063](https://github.com/JosefPihrt/Roslynator/pull/1063/files)).
 
 
 ## [4.2.0] - 2022-11-27

--- a/src/Tests/Analyzers.Tests/RCS1009UseExplicitTypeInsteadOfVarInForEachTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1009UseExplicitTypeInsteadOfVarInForEachTests.cs
@@ -169,4 +169,77 @@ class C
     }
 }");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseExplicitTypeInsteadOfVarWhenTypeIsObvious)]
+    public async Task Test_TupleExpression_WithDiscardPredefinedType()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        var items = new List<(object, System.DateTime)>();
+
+        foreach ([|var|] (_, y) in items)
+        {
+        }
+    }
+}
+", @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        var items = new List<(object, System.DateTime)>();
+
+        foreach ((object _, DateTime y) in items)
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseExplicitTypeInsteadOfVarWhenTypeIsObvious)]
+        public async Task Test_TupleExpression_WithDiscardNonPredefinedType()
+        {
+            await VerifyDiagnosticAndFixAsync(@"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        var items = new List<(object, System.DateTime)>();
+
+        foreach ([|var|] (x, _) in items)
+        {
+        }
+    }
+}
+", @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        var items = new List<(object, System.DateTime)>();
+
+        foreach ((object x, DateTime _) in items)
+        {
+        }
+    }
+}
+");
+    }
+
 }

--- a/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
+++ b/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
@@ -97,14 +97,11 @@ internal static class DocumentRefactorings
             {
                 if (f.Expression is DeclarationExpressionSyntax declarationExpression)
                     return f.WithExpression(declarationExpression.WithType(declarationExpression.Type.WithSimplifierAnnotation()));
-                if (f.Expression is PredefinedTypeSyntax predefinedTypeSyntax)
-                    return f.WithExpression(DeclarationExpression(predefinedTypeSyntax, DiscardDesignation()));
-                if (f.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax)
+                if (f.Expression is PredefinedTypeSyntax or MemberAccessExpressionSyntax)
                 {
-                    TypeSyntax typeSyntax = GetQualifiedName(memberAccessExpressionSyntax).WithSimplifierAnnotation();
-                    return f.WithExpression(DeclarationExpression(typeSyntax, DiscardDesignation()));
+                    return f.WithExpression(DeclarationExpression(ParseTypeName(f.Expression.ToString()).WithSimplifierAnnotation(), DiscardDesignation()));
                 }
-
+                
                 SyntaxDebug.Fail(f.Expression);
 
                 return f;
@@ -113,23 +110,7 @@ internal static class DocumentRefactorings
 
         return tupleExpression.WithArguments(newArguments);
     }
-
-
-    private static QualifiedNameSyntax GetQualifiedName(MemberAccessExpressionSyntax memberAccessExpressionSyntax)
-    {
-        if (memberAccessExpressionSyntax.Expression is AliasQualifiedNameSyntax aliasQualifiedNameSyntax)
-        {
-            return QualifiedName(aliasQualifiedNameSyntax, memberAccessExpressionSyntax.Name);
-        }
-
-        if (memberAccessExpressionSyntax.Expression is MemberAccessExpressionSyntax left)
-        {
-            return QualifiedName(GetQualifiedName(left), memberAccessExpressionSyntax.Name);
-        }
-
-        throw new ArgumentException(nameof(memberAccessExpressionSyntax));
-    }
-
+    
     public static Task<Document> ChangeTypeToVarAsync(
         Document document,
         TypeSyntax type,

--- a/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
+++ b/src/Workspaces.Common/CSharp/DocumentRefactorings.cs
@@ -110,7 +110,6 @@ internal static class DocumentRefactorings
 
         return tupleExpression.WithArguments(newArguments);
     }
-    
     public static Task<Document> ChangeTypeToVarAsync(
         Document document,
         TypeSyntax type,


### PR DESCRIPTION
Currently, if you try to apply RCS1009 on a for each which contains discards e.g.
```
foreach(var (x,_) in items){...}
```
Then it will fail since these do not get parsed as DeclarationExpressions at Document Refactorings [L92](https://github.com/JosefPihrt/Roslynator/blob/78e385f810812efb6aec7b47ecf7740d80870cd6/src/Workspaces.Common/CSharp/DocumentRefactorings.cs#L92). This PR fixes this by adding cases for PredefinedTypeSyntax and MemberAccessExpression which are what `string _` and `System.DateTime _` get parsed to respectively. 