### PR TITLE
RCS1032: Include handling for SimpleMemberAccess

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [CLI] Analyze command does not create the XML output file and returns incorrect exit code when only compiler diagnostics are reported ([#1056](https://github.com/JosefPihrt/Roslynator/pull/1056) by @PeterKaszab).
 - [CLI] Fix exit code when multiple projects are processed ([#1061](https://github.com/JosefPihrt/Roslynator/pull/1061) by @PeterKaszab).
 - Fix code fix for CS0164 ([#1031](https://github.com/JosefPihrt/Roslynator/pull/1031)).
+- Fix RCS1032 ([#1064](https://github.com/JosefPihrt/Roslynator/pull/1064)).
 
 
 ## [4.2.0] - 2022-11-27

--- a/src/Analyzers/CSharp/Analysis/RemoveRedundantParenthesesAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/RemoveRedundantParenthesesAnalyzer.cs
@@ -92,7 +92,8 @@ public sealed class RemoveRedundantParenthesesAnalyzer : BaseDiagnosticAnalyzer
             case SyntaxKind.GreaterThanOrEqualExpression:
             case SyntaxKind.EqualsExpression:
             case SyntaxKind.NotEqualsExpression:
-                {
+            case SyntaxKind.SimpleMemberAccessExpression:
+               {
                     if (expression.IsKind(SyntaxKind.IdentifierName)
                         || expression is LiteralExpressionSyntax)
                     {

--- a/src/Tests/Analyzers.Tests/RCS1032RemoveRedundantParenthesesTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1032RemoveRedundantParenthesesTests.cs
@@ -254,6 +254,7 @@ class C
     [InlineData(@"M([|(|]""""));", @"M("""");")]
     [InlineData("var arr = new string[] { [|(|]null) };", "var arr = new string[] { null };")]
     [InlineData("var items = new List<string>() { [|(|]null) };", "var items = new List<string>() { null };")]
+    [InlineData("var x = [|(|]i).ToString();","var x = i.ToString();")]
     [InlineData(@"s = $""{[|(|]"""")}"";", @"s = $""{""""}"";")]
     [InlineData("[|(|]i) = [|(|]0);", "i = 0;")]
     [InlineData("[|(|]i) += [|(|]0);", "i += 0;")]


### PR DESCRIPTION
Currently, RCS1032 won't be suggested for SimpleMemberAccesses e.g.
```
(X).Y
```
This PR adds support for this.