### PR TITLE
Improve SyntaxLogicalInverter to Handling Additional Cases and reduce Unnecesarry Parentheses

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve inversion of logical expressions to handling additional cases ([#1086](https://github.com/josefpihrt/roslynator/pull/1086)).
+
 ## [4.3.0] - 2023-04-24
 
 ### Changed

--- a/src/CSharp.Workspaces/CSharp/SyntaxLogicalInverter.cs
+++ b/src/CSharp.Workspaces/CSharp/SyntaxLogicalInverter.cs
@@ -76,9 +76,7 @@ public class SyntaxLogicalInverter
             return null;
 
         var inverted = LogicallyInvertImpl(expression, semanticModel, cancellationToken);
-        if (inverted.IsKind(SyntaxKind.LogicalNotExpression, SyntaxKind.ParenthesizedExpression))
-            return inverted;
-        return inverted.Parenthesize();
+        return inverted.IsKind(SyntaxKind.LogicalNotExpression, SyntaxKind.ParenthesizedExpression) ? inverted : inverted.Parenthesize();
     }
 
     private ExpressionSyntax LogicallyInvertImpl(
@@ -98,9 +96,10 @@ public class SyntaxLogicalInverter
             case SyntaxKind.CheckedExpression:
             case SyntaxKind.UncheckedExpression:
             case SyntaxKind.DefaultExpression:
-            {
-                return DefaultInvert(expression, false);
-            }
+            case SyntaxKind.ConditionalAccessExpression:
+                {
+                    return DefaultInvert(expression, false);
+                }
             case SyntaxKind.PostIncrementExpression:
             case SyntaxKind.PostDecrementExpression:
             case SyntaxKind.ObjectCreationExpression:
@@ -506,7 +505,7 @@ public class SyntaxLogicalInverter
 
                 return isPattern.WithPattern(newConstantPattern);
             }
-            else if (constantExpression.IsKind(SyntaxKind.NullLiteralExpression,SyntaxKind.NumericLiteralExpression,SyntaxKind.StringLiteralExpression))
+            else if (constantExpression.IsKind(SyntaxKind.NullLiteralExpression, SyntaxKind.NumericLiteralExpression, SyntaxKind.StringLiteralExpression))
             {
                 UnaryPatternSyntax notPattern = NotPattern(constantPattern.WithoutTrivia()).WithTriviaFrom(constantPattern);
 
@@ -521,13 +520,13 @@ public class SyntaxLogicalInverter
         return DefaultInvert(isPattern);
     }
 
-    private static PrefixUnaryExpressionSyntax DefaultInvert(ExpressionSyntax expression, bool needsParenthesize=true)
+    private static PrefixUnaryExpressionSyntax DefaultInvert(ExpressionSyntax expression, bool needsParenthesize = true)
     {
         SyntaxDebug.Assert(expression.Kind() != SyntaxKind.ParenthesizedExpression, expression);
 
         SyntaxTriviaList leadingTrivia = expression.GetLeadingTrivia();
         expression = expression.WithoutLeadingTrivia();
-        if(needsParenthesize)
+        if (needsParenthesize)
             expression = expression.Parenthesize();
 
         return LogicalNotExpression(

--- a/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
+++ b/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Roslynator.CSharp.Workspaces.Tests;
+
+public class SyntaxLogicallyInvertTests
+{
+    private SyntaxLogicalInverter _inverter;
+
+    public SyntaxLogicallyInvertTests()
+    {
+        _inverter = SyntaxLogicalInverter.Default;
+    }
+
+    [Theory]
+    [InlineData(@"x", @"!x")]
+    [InlineData(@"!x", @"x")]
+    [InlineData(@"x is ""abc""", @"x is not ""abc""")]
+    [InlineData(@"x is 1", @"x is not 1")]
+    [InlineData(@"x is null", @"x is not null")]
+    [InlineData(@"x is true", @"x is false")]
+    [InlineData(@"true", @"false")]
+    [InlineData(@"false", @"true")]
+    [InlineData(@"x >= 3", @"x < 3")]
+    [InlineData(@"x > 3", @"x <= 3")]
+    [InlineData(@"x <= 3", @"x > 3")]
+    [InlineData(@"x < 3", @"x >= 3")]
+    [InlineData(@"x == y", @"x != y")]
+    [InlineData(@"x != y", @"x == y")]
+    [InlineData(@"(bool)x || (bool)y", @"!((bool)x) && !((bool)y)")]
+    [InlineData(@"(bool)x && (bool)y", @"!((bool)x) || !((bool)y)")]
+    [InlineData(@"x ?? true", @"x == false")]
+    [InlineData(@"x ?? false", @"x != true")]
+    [InlineData(@"(bool)x ? y : z", @"(bool)x ? !y : !z")]
+    [InlineData(@"x[0]", @"!x[0]")]
+    [InlineData(@"default(bool)", @"!default(bool)")]
+    [InlineData(@"checked(x + y)", @"!checked(x + y)")]
+    [InlineData(@"unchecked(x + y)", @"!unchecked(x + y)")]
+    [InlineData(@"(bool)x", @"!((bool)x)")]
+    [InlineData(@"x & y", @"!x | !y")]
+    [InlineData(@"x ^ y", @"!(x ^ y)")]
+    [InlineData(@"x | y", @"!x & !y")]
+    [InlineData(@"x = y", @"!(x = y)")]
+    [InlineData(@"await x", @"!(await x)")]
+    [InlineData(@"x ?? y", @"!(x ?? y)")]
+    [InlineData(@"x.a", @"!x.a")]
+    [InlineData(@"x.a()", @"!x.a()")]
+    public async Task LogicallyInvert(string source, string expected)
+    {
+        var sourceCode = $"class C {{ void M(dynamic x, dynamic y, dynamic z){{ if({source})return;}} }}";
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var versionStamp = VersionStamp.Create();
+        var projectInfo = ProjectInfo.Create(projectId, versionStamp, "TestProject", "TestProject", LanguageNames.CSharp);
+        var newProject = workspace.AddProject(projectInfo);
+        var newDocument = workspace.AddDocument(newProject.Id, "TestDocument.cs", SourceText.From(sourceCode));
+        var syntaxTree = await newDocument.GetSyntaxTreeAsync();
+        var compilation = await newDocument.Project.GetCompilationAsync();
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+        var expression = syntaxTree.GetRoot().DescendantNodes().OfType<IfStatementSyntax>().Single().Condition;
+
+        var result = _inverter.LogicallyInvert(expression, semanticModel, CancellationToken.None);
+        Assert.Equal(expected, result.NormalizeWhitespace().ToFullString());
+    }
+
+}

--- a/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
+++ b/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
@@ -54,10 +54,7 @@ public class SyntaxLogicallyInvertTests
     {
         var sourceCode = $"class C {{ void M(dynamic x, dynamic y, dynamic z){{ if({source})return;}} }}";
         var workspace = new AdhocWorkspace();
-        var projectId = ProjectId.CreateNewId();
-        var versionStamp = VersionStamp.Create();
-        var projectInfo = ProjectInfo.Create(projectId, versionStamp, "TestProject", "TestProject", LanguageNames.CSharp);
-        var newProject = workspace.AddProject(projectInfo);
+        var newProject = workspace.AddProject("TestProject", LanguageNames.CSharp);
         var newDocument = workspace.AddDocument(newProject.Id, "TestDocument.cs", SourceText.From(sourceCode));
         var syntaxTree = await newDocument.GetSyntaxTreeAsync();
         var compilation = await newDocument.Project.GetCompilationAsync();

--- a/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
+++ b/src/Tests/CSharp.Workspaces.Tests/SyntaxLogicalInverterTests.cs
@@ -50,6 +50,7 @@ public class SyntaxLogicallyInvertTests
     [InlineData(@"x ?? y", @"!(x ?? y)")]
     [InlineData(@"x.a", @"!x.a")]
     [InlineData(@"x.a()", @"!x.a()")]
+    [InlineData(@"x?.a", @"!x?.a")]
     public async Task LogicallyInvert(string source, string expected)
     {
         var sourceCode = $"class C {{ void M(dynamic x, dynamic y, dynamic z){{ if({source})return;}} }}";


### PR DESCRIPTION
This PR updates the SyntaxLogicalInverter to handle a couple of new cases (NumericLiteralExpression, and StringLiteralExpression) - these were previously failing if running in debug mode e.g. causing errors in RCS1208. 
Other changes of note:
- Avoid adding parens for cases where it is clear that we do not need to add them.
- Add a number of unit tests to ensure that things are working as they should.