### PR TITLE
RCS1016 result doesn't compile fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix [RCS1016](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1016.md) ([#1090](https://github.com/josefpihrt/roslynator/pull/1090)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/src/CSharp/CSharp/SyntaxRewriters/WhitespaceRemover.cs
+++ b/src/CSharp/CSharp/SyntaxRewriters/WhitespaceRemover.cs
@@ -48,7 +48,7 @@ internal sealed class WhitespaceRemover : CSharpSyntaxRewriter
             if (!prevTrivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
                 return Replacement;
         }
-        
+
         return base.VisitTrivia(trivia);
     }
 }

--- a/src/Tests/Analyzers.Tests/RCS1016UseBlockBodyTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1016UseBlockBodyTests.cs
@@ -247,6 +247,28 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseBlockBodyOrExpressionBody)]
+    public async Task Test_GetterTrailingComment()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+class C
+{
+    string P [|=> null|]; // some comment
+}
+", @"
+class C
+{
+    string P
+    {
+        get
+        {
+            return null;// some comment
+        }
+    }
+}
+", options: Options.AddConfigOption(ConfigOptionKeys.BodyStyle, ConfigOptionValues.BodyStyle_Block));
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseBlockBodyOrExpressionBody)]
     public async Task Test_PropertyWithGetter_MultilineExpression()
     {
         await VerifyDiagnosticAndFixAsync(@"


### PR DESCRIPTION
If there is a trailing comment after an arrow expression then applying RCS1016 will produce code that fails to compile as the trailing '}' will be appended to the comment.

For example: 
```
string P => null; // some comment
```
becomes:
```
string P { 
    get { return null;// some comment}
}
```

The cause is that the WhitespaceRemover is removing newlines even if they are preceded by a comment.