### PR TITLE
Fix RCS1047 for various IAsyncEnumerable shapes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Fix [RCS1016](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1016.md) ([#1090](https://github.com/josefpihrt/roslynator/pull/1090)).
+- Recognize more shapes of IAsyncEnumerable as being Async ([RCS1047](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1047.md)) ([#1084](https://github.com/josefpihrt/roslynator/pull/1084)).
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix [RCS1016](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1016.md) ([#1090](https://github.com/josefpihrt/roslynator/pull/1090)).
-- Recognize more shapes of IAsyncEnumerable as being Async ([RCS1047](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1047.md)) ([#1084](https://github.com/josefpihrt/roslynator/pull/1084)).
 
 ### Fixed
 
+- Fix [RCS1016](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1016.md) ([#1090](https://github.com/josefpihrt/roslynator/pull/1090)).
 - Improve inversion of logical expressions to handling additional cases ([#1086](https://github.com/josefpihrt/roslynator/pull/1086)).
 - Fix [RCS1084](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1084.md) ([#1085](https://github.com/josefpihrt/roslynator/pull/1085)).
 - Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
+- Recognize more shapes of IAsyncEnumerable as being Async ([RCS1047](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1047.md)) ([#1084](https://github.com/josefpihrt/roslynator/pull/1084)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/src/Core/MetadataNames.cs
+++ b/src/Core/MetadataNames.cs
@@ -45,6 +45,7 @@ internal static class MetadataNames
     public static readonly MetadataName System_Linq_IOrderedEnumerable_T = MetadataName.Parse("System.Linq.IOrderedEnumerable`1");
     public static readonly MetadataName System_Linq_IQueryable_T = MetadataName.Parse("System.Linq.IQueryable`1");
     public static readonly MetadataName System_NonSerializedAttribute = MetadataName.Parse("System.NonSerializedAttribute");
+    public static readonly MetadataName System_Object = MetadataName.Parse("System.Object");
     public static readonly MetadataName System_ObsoleteAttribute = MetadataName.Parse("System.ObsoleteAttribute");
     public static readonly MetadataName System_Reflection = MetadataName.Parse("System.Reflection");
     public static readonly MetadataName System_Runtime_CompilerServices = MetadataName.Parse("System.Runtime.CompilerServices");
@@ -59,6 +60,7 @@ internal static class MetadataNames
     public static readonly MetadataName System_Text_RegularExpressions_Regex = MetadataName.Parse("System.Text.RegularExpressions.Regex");
     public static readonly MetadataName System_Text_RegularExpressions_RegexOptions = MetadataName.Parse("System.Text.RegularExpressions.RegexOptions");
     public static readonly MetadataName System_Text_StringBuilder = MetadataName.Parse("System.Text.StringBuilder");
+    public static readonly MetadataName System_Threading_CancellationToken = MetadataName.Parse("System.Threading.CancellationToken");
     public static readonly MetadataName System_Threading_Tasks = MetadataName.Parse("System.Threading.Tasks");
     public static readonly MetadataName System_Threading_Tasks_Task = MetadataName.Parse("System.Threading.Tasks.Task");
     public static readonly MetadataName System_Threading_Tasks_Task_T = MetadataName.Parse("System.Threading.Tasks.Task`1");

--- a/src/Core/MetadataNames.cs
+++ b/src/Core/MetadataNames.cs
@@ -45,7 +45,6 @@ internal static class MetadataNames
     public static readonly MetadataName System_Linq_IOrderedEnumerable_T = MetadataName.Parse("System.Linq.IOrderedEnumerable`1");
     public static readonly MetadataName System_Linq_IQueryable_T = MetadataName.Parse("System.Linq.IQueryable`1");
     public static readonly MetadataName System_NonSerializedAttribute = MetadataName.Parse("System.NonSerializedAttribute");
-    public static readonly MetadataName System_Object = MetadataName.Parse("System.Object");
     public static readonly MetadataName System_ObsoleteAttribute = MetadataName.Parse("System.ObsoleteAttribute");
     public static readonly MetadataName System_Reflection = MetadataName.Parse("System.Reflection");
     public static readonly MetadataName System_Runtime_CompilerServices = MetadataName.Parse("System.Runtime.CompilerServices");

--- a/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1047NonAsynchronousMethodNameShouldNotEndWithAsyncTests.cs
@@ -92,7 +92,7 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.NonAsynchronousMethodNameShouldNotEndWithAsync)]
-    public async Task TestNoDiagnostic()
+    public async Task TestNoDiagnostic_Task()
     {
         await VerifyNoDiagnosticAsync(@"
 using System.Threading.Tasks;
@@ -127,6 +127,84 @@ class C
     ValueTask<object> ValueTaskOfTAsync()
     {
         return default(ValueTask<object>);
+    }
+
+    ValueTask ValueTaskAsync()
+    {
+        return default(ValueTask);
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.NonAsynchronousMethodNameShouldNotEndWithAsync)]
+    public async Task TestNoDiagnostic_AsyncEnumerable()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+class C
+{
+    IAsyncEnumerable<object> GetAsyncEnumerableAsync()
+    {
+        return null;
+    }
+
+    AsyncEnumerableImpl GetAsyncEnumerableImplAsync()
+    {
+        return null;
+    }
+
+    T GetAsyncEnumerableImplOfAsync<T>() where T : AsyncEnumerableImpl
+    {
+        return default(T);
+    }
+
+    T AsyncEnumerableOfTAsync<T>() where T : IAsyncEnumerable<object>
+    {
+        return default(T);
+    }
+
+    InheritsImpl GetInheritingImplAsync()
+    {
+        return null;
+    }
+
+    T GetInheritingImplOfAsync<T>() where T : InheritsImpl
+    {
+        return default(T);
+    }
+
+    DuckTyped GetDuckTypedAsync()
+    {
+        return null;
+    }
+
+    T GetDuckTypedOfTAsync<T>() where T : DuckTyped
+    {
+        return default(T);
+    }
+}
+
+class AsyncEnumerableImpl : IAsyncEnumerable<object>
+{
+    public IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return null;
+    }
+}
+
+class InheritsImpl : AsyncEnumerableImpl
+{
+}
+
+class DuckTyped
+{
+    public IAsyncEnumerator<object> GetAsyncEnumerator()
+    {
+        return null;
     }
 }
 ");


### PR DESCRIPTION
closes #1084

Unsure if I should add the line to changelog, let me know if it needs to be removed.

Decided to include support for duck-typed `GetAsyncEnumerator()` after all, but left the analysis at that. The fact that the enumerator can be duck typed too (and via generics as well!). The current implementation should handle 99,9%+ of cases. If the inheritance walking and method existence checks are too heavy, let me know and I'll remove them and leave just the generics/interface impl support.

To demonstrate the madness that full duck typing support could possibly have, this compiles fine:
```csharp
await foreach (var a in new C().GetTObjAsync<IAsyncEnumerator<object?>>())
{
}

class C
{
    public Obj<T> GetTObjAsync<T>()
    {
        throw new NotImplementedException();
    }
}

abstract class Obj<T>
{
    public abstract T GetAsyncEnumerator();
}
```