### PR TITLE
Fix RCS1169

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
+
 ## [4.3.0] - 2023-04-24
 
 ### Changed

--- a/src/Analyzers/CSharp/Analysis/MakeMemberReadOnly/MakeMemberReadOnlyWalker.cs
+++ b/src/Analyzers/CSharp/Analysis/MakeMemberReadOnly/MakeMemberReadOnlyWalker.cs
@@ -67,6 +67,13 @@ internal class MakeMemberReadOnlyWalker : AssignedExpressionWalker
     {
         SyntaxKind kind = expression.Kind();
 
+        if (kind == SyntaxKind.SuppressNullableWarningExpression)
+        {
+            var postfixUnaryExpression = (PostfixUnaryExpressionSyntax)expression;
+            expression = postfixUnaryExpression.Operand;
+            kind = expression.Kind();
+        }
+
         if (kind == SyntaxKind.IdentifierName)
         {
             AnalyzeAssigned((IdentifierNameSyntax)expression);

--- a/src/Analyzers/CSharp/Analysis/MakeMemberReadOnly/MakeMemberReadOnlyWalker.cs
+++ b/src/Analyzers/CSharp/Analysis/MakeMemberReadOnly/MakeMemberReadOnlyWalker.cs
@@ -137,10 +137,8 @@ internal class MakeMemberReadOnlyWalker : AssignedExpressionWalker
         {
             VisitAssignedExpression(expression);
         }
-        else
-        {
-            base.VisitRefExpression(node);
-        }
+
+        base.VisitRefExpression(node);
     }
 
     public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)

--- a/src/Tests/Analyzers.Tests/RCS1169MakeFieldReadOnlyTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1169MakeFieldReadOnlyTests.cs
@@ -365,4 +365,16 @@ class C
 ");
     }
 
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MakeFieldReadOnly)]
+    public async Task TestNoDiagnostic_RefInRef()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System.Runtime.CompilerServices;
+class C
+{
+    int _a;
+    ref int M2() {return ref Unsafe.Add(ref _a, 3);} 
+}
+");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1169MakeFieldReadOnlyTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1169MakeFieldReadOnlyTests.cs
@@ -350,4 +350,19 @@ class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MakeFieldReadOnly)]
+    public async Task TestNoDiagnostic_SuppressNullableWarning()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    int _a;
+
+    void M(ref int x) {}
+    void M2() {M(ref _a!);} 
+}
+");
+    }
+
 }


### PR DESCRIPTION
Currently, RCS1169 will suggest setting variables to read-only in cases which would cause compile-time errors such as the following:
```
class C
{
    int _a;
    void M2() {M(ref _a!);} 
}
```
This is because when working out what symbols have values assigned to them outside a constructor it currently does not consider symbols that have the SuppressNullableWarning suffix (`!`).

There is another minor issue is that anything inside the ref expression is not being considered by the MakeMemberReadonlyWalker. 
