### PR TITLE
Fix RCS1197

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix [RCS1197](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1197.md) [#10093](https://github.com/JosefPihrt/Roslynator/pull/1093).
+
 ## [4.3.0] - 2023-04-24
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve inversion of logical expressions to handling additional cases ([#1086](https://github.com/josefpihrt/roslynator/pull/1086)).
 - Fix [RCS1084](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1084.md) ([#1085](https://github.com/josefpihrt/roslynator/pull/1085)).
 - Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
-- Fix [RCS1197](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1197.md) [#10093](https://github.com/JosefPihrt/Roslynator/pull/1093).
+- Fix [RCS1197](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1197.md) ([#1093](https://github.com/JosefPihrt/Roslynator/pull/1093)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve inversion of logical expressions to handling additional cases ([#1086](https://github.com/josefpihrt/roslynator/pull/1086)).
 - Fix [RCS1084](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1084.md) ([#1085](https://github.com/josefpihrt/roslynator/pull/1085)).
 - Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
-
-### Fixed
-
 - Fix [RCS1197](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1197.md) [#10093](https://github.com/JosefPihrt/Roslynator/pull/1093).
 
 ## [4.3.0] - 2023-04-24

--- a/src/Tests/Analyzers.Tests/RCS1197OptimizeStringBuilderAppendCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1197OptimizeStringBuilderAppendCallTests.cs
@@ -527,6 +527,38 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeStringBuilderAppendCall)]
+    public async Task Test_InterpolatedString_WithFormat_AppendLine2()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System;
+using System.Text;
+
+class C
+{
+    void M(DateTime x)
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.Append([|$@""{x:hh\:mm\:ss\.fff}""|]).ToString();
+    }
+}
+", @"
+using System;
+using System.Text;
+
+class C
+{
+    void M(DateTime x)
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.AppendFormat(@""{0:hh\:mm\:ss\.fff}"", x).ToString();
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeStringBuilderAppendCall)]
     public async Task Test_Concatenation()
     {
         await VerifyDiagnosticAndFixAsync(@"

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
@@ -35,6 +35,11 @@ internal static class ConvertInterpolatedStringToStringBuilderMethodRefactoring
                     {
                         StringBuilder sb = StringBuilderCache.GetInstance();
 
+                        if (isVerbatim)
+                        {
+                            sb.Append("@");
+                        }
+
                         sb.Append("\"{0");
 
                         if (alignmentClause is not null)

--- a/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/ConvertInterpolatedStringToStringBuilderMethodRefactoring.cs
@@ -36,9 +36,7 @@ internal static class ConvertInterpolatedStringToStringBuilderMethodRefactoring
                         StringBuilder sb = StringBuilderCache.GetInstance();
 
                         if (isVerbatim)
-                        {
                             sb.Append("@");
-                        }
 
                         sb.Append("\"{0");
 


### PR DESCRIPTION
An interpolated string can also be a verbatim string. Currently, The code fix for RCS1197 will not retain the verbatim `@` when optimizing a string interpolation which means that the resulting code doesn't compile. 

For example 
```
stringBuilder.Append($@"{x:hh\:mm\:ss\.fff}"));
```
Becomes
```
stringBuilder.AppendFormat("{0:hh\:mm\:ss\.fff}",x));
```