### PR TITLE
Fix RCS1056

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve inversion of logical expressions to handling additional cases ([#1086](https://github.com/josefpihrt/roslynator/pull/1086)).
 - Fix [RCS1084](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1084.md) ([#1085](https://github.com/josefpihrt/roslynator/pull/1085)).
 - Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
+- Fix [RCS1056](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1056.md) ([#1096](https://github.com/JosefPihrt/Roslynator/pull/1096)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/src/CSharp/CSharp/Syntax/UsingDirectiveListInfo.cs
+++ b/src/CSharp/CSharp/Syntax/UsingDirectiveListInfo.cs
@@ -113,6 +113,11 @@ public readonly struct UsingDirectiveListInfo : IReadOnlyList<UsingDirectiveSynt
                     var namespaceDeclaration = (NamespaceDeclarationSyntax)declaration;
                     return new UsingDirectiveListInfo(namespaceDeclaration, namespaceDeclaration.Usings);
                 }
+            case SyntaxKind.FileScopedNamespaceDeclaration:
+            {
+                var fileScopedNamespaceDeclaration = (FileScopedNamespaceDeclarationSyntax)declaration;
+                return new UsingDirectiveListInfo(fileScopedNamespaceDeclaration, fileScopedNamespaceDeclaration.Usings);
+            }
         }
 
         return default;

--- a/src/CSharp/CSharp/Syntax/UsingDirectiveListInfo.cs
+++ b/src/CSharp/CSharp/Syntax/UsingDirectiveListInfo.cs
@@ -91,6 +91,14 @@ public readonly struct UsingDirectiveListInfo : IReadOnlyList<UsingDirectiveSynt
         return new UsingDirectiveListInfo(namespaceDeclaration, namespaceDeclaration.Usings);
     }
 
+    internal static UsingDirectiveListInfo Create(FileScopedNamespaceDeclarationSyntax namespaceDeclaration)
+    {
+        if (namespaceDeclaration is null)
+            return default;
+
+        return new UsingDirectiveListInfo(namespaceDeclaration, namespaceDeclaration.Usings);
+    }
+
     internal static UsingDirectiveListInfo Create(CompilationUnitSyntax compilationUnit)
     {
         if (compilationUnit is null)
@@ -114,10 +122,10 @@ public readonly struct UsingDirectiveListInfo : IReadOnlyList<UsingDirectiveSynt
                     return new UsingDirectiveListInfo(namespaceDeclaration, namespaceDeclaration.Usings);
                 }
             case SyntaxKind.FileScopedNamespaceDeclaration:
-            {
-                var fileScopedNamespaceDeclaration = (FileScopedNamespaceDeclarationSyntax)declaration;
-                return new UsingDirectiveListInfo(fileScopedNamespaceDeclaration, fileScopedNamespaceDeclaration.Usings);
-            }
+                {
+                    var fileScopedNamespaceDeclaration = (FileScopedNamespaceDeclarationSyntax)declaration;
+                    return new UsingDirectiveListInfo(fileScopedNamespaceDeclaration, fileScopedNamespaceDeclaration.Usings);
+                }
         }
 
         return default;

--- a/src/CSharp/CSharp/SyntaxInfo.cs
+++ b/src/CSharp/CSharp/SyntaxInfo.cs
@@ -1089,6 +1089,15 @@ public static class SyntaxInfo
     }
 
     /// <summary>
+    /// Creates a new <see cref="Syntax.UsingDirectiveListInfo"/> from the specified declaration.
+    /// </summary>
+    /// <param name="declaration"></param>
+    public static UsingDirectiveListInfo UsingDirectiveListInfo(FileScopedNamespaceDeclarationSyntax declaration)
+    {
+        return Syntax.UsingDirectiveListInfo.Create(declaration);
+    }
+
+    /// <summary>
     /// Creates a new <see cref="Syntax.XmlElementInfo"/> from the specified xml node.
     /// </summary>
     /// <param name="xmlNode"></param>

--- a/src/Tests/Analyzers.Tests/RCS1056AvoidUsageOfUsingAliasDirectiveTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1056AvoidUsageOfUsingAliasDirectiveTests.cs
@@ -78,4 +78,35 @@ class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AvoidUsageOfUsingAliasDirective)]
+    public async Task Test_BlockNamespaces()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+namespace BlockNamespace
+{
+    [|using s = System;|]
+
+    class C
+    {
+        void M()
+        {
+            string u1 = s.String.Empty;
+        }
+    }
+}
+", @"
+namespace BlockNamespace
+{
+
+    class C
+    {
+        void M()
+        {
+            string u1 = System.String.Empty;
+        }
+    }
+}
+");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1056AvoidUsageOfUsingAliasDirectiveTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1056AvoidUsageOfUsingAliasDirectiveTests.cs
@@ -51,4 +51,31 @@ class C
 }
 ");
     }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.AvoidUsageOfUsingAliasDirective)]
+    public async Task Test_FileScopedNamespaces()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+namespace FileScopedNamespace;
+[|using s = System;|]
+
+class C
+{
+    void M()
+    {
+        string u1 = s.String.Empty;
+    }
+}
+", @"
+namespace FileScopedNamespace;
+
+class C
+{
+    void M()
+    {
+        string u1 = System.String.Empty;
+    }
+}
+");
+    }
 }

--- a/src/Workspaces.Common/CSharp/Refactorings/InlineAliasExpressionRefactoring.cs
+++ b/src/Workspaces.Common/CSharp/Refactorings/InlineAliasExpressionRefactoring.cs
@@ -22,7 +22,7 @@ internal static class InlineAliasExpressionRefactoring
 
         SyntaxNode parent = usingDirective.Parent;
 
-        Debug.Assert(parent.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration), "");
+        Debug.Assert(parent.IsKind(SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration, SyntaxKind.FileScopedNamespaceDeclaration), "");
 
         int index = SyntaxInfo.UsingDirectiveListInfo(parent).IndexOf(usingDirective);
 
@@ -43,6 +43,8 @@ internal static class InlineAliasExpressionRefactoring
                 return compilationUnit.RemoveNode(compilationUnit.Usings[index]);
             case NamespaceDeclarationSyntax namespaceDeclaration:
                 return namespaceDeclaration.RemoveNode(namespaceDeclaration.Usings[index]);
+            case FileScopedNamespaceDeclarationSyntax fileScopedNamespaceDeclaration:
+                return fileScopedNamespaceDeclaration.RemoveNode(fileScopedNamespaceDeclaration.Usings[index]);
         }
 
         return node;


### PR DESCRIPTION
Currently, RCS1056 does not handle using inside FileScopedNamespaces correctly (In debug mode it will just fail). See tests for reproduction.