### PR TITLE
Fix RCS1146

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix [RCS1169](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1169.md) ([#1092](https://github.com/JosefPihrt/Roslynator/pull/1092)).
 - Recognize more shapes of IAsyncEnumerable as being Async ([RCS1047](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1047.md)) ([#1084](https://github.com/josefpihrt/roslynator/pull/1084)).
 - Fix [RCS1197](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1197.md) ([#1093](https://github.com/JosefPihrt/Roslynator/pull/1093)).
+- Fix [RCS1146](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1146.md) ([#1098](https://github.com/JosefPihrt/Roslynator/pull/1098)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
@@ -275,6 +275,10 @@ public sealed class UseConditionalAccessAnalyzer : BaseDiagnosticAnalyzer
                 case SyntaxKind.EqualsExpression:
                     {
                         var leftTypeSymbol = semanticModel.GetTypeSymbol(((BinaryExpressionSyntax)expression).Left);
+
+                        if (leftTypeSymbol.IsErrorType())
+                            return false;
+
                         if (leftTypeSymbol.IsValueType && !CSharpFacts.IsPredefinedType(leftTypeSymbol.SpecialType))
                         { 
                             // If the LHS is a ValueTypes then making the expression conditional would change the type of the expression

--- a/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
@@ -275,7 +275,7 @@ public sealed class UseConditionalAccessAnalyzer : BaseDiagnosticAnalyzer
                 case SyntaxKind.EqualsExpression:
                     {
                         var leftTypeSymbol = semanticModel.GetTypeSymbol(((BinaryExpressionSyntax)expression).Left);
-                        if (leftTypeSymbol.IsValueType && CSharpFacts.IsPredefinedType(leftTypeSymbol.SpecialType))
+                        if (leftTypeSymbol.IsValueType && !CSharpFacts.IsPredefinedType(leftTypeSymbol.SpecialType))
                         { 
                             // If the LHS is a ValueTypes then making the expression conditional would change the type of the expression
                             // and hence we would call a different overload (a valid overload may not exists)

--- a/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
@@ -275,7 +275,7 @@ public sealed class UseConditionalAccessAnalyzer : BaseDiagnosticAnalyzer
                 case SyntaxKind.EqualsExpression:
                     {
                         var leftTypeSymbol = semanticModel.GetTypeSymbol(((BinaryExpressionSyntax)expression).Left);
-                        if (leftTypeSymbol.IsValueType && leftTypeSymbol.SpecialType is SpecialType.None)
+                        if (leftTypeSymbol.IsValueType && CSharpFacts.IsPredefinedType(leftTypeSymbol.SpecialType))
                         { 
                             // If the LHS is a ValueTypes then making the expression conditional would change the type of the expression
                             // and hence we would call a different overload (a valid overload may not exists)

--- a/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/UseConditionalAccessAnalyzer.cs
@@ -274,6 +274,14 @@ public sealed class UseConditionalAccessAnalyzer : BaseDiagnosticAnalyzer
                 case SyntaxKind.GreaterThanOrEqualExpression:
                 case SyntaxKind.EqualsExpression:
                     {
+                        var leftTypeSymbol = semanticModel.GetTypeSymbol(((BinaryExpressionSyntax)expression).Left);
+                        if (leftTypeSymbol.IsValueType && leftTypeSymbol.SpecialType is SpecialType.None)
+                        { 
+                            // If the LHS is a ValueTypes then making the expression conditional would change the type of the expression
+                            // and hence we would call a different overload (a valid overload may not exists)
+                            return false;
+                        }
+                        
                         expression = ((BinaryExpressionSyntax)expression)
                             .Right?
                             .WalkDownParentheses();

--- a/src/Tests/Analyzers.Tests/RCS1146UseConditionalAccessTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1146UseConditionalAccessTests.cs
@@ -602,6 +602,26 @@ struct Foo
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseConditionalAccess)]
+    public async Task TestNoDiagnostic_LogicalAnd_ValueTypeFieldAccess()
+    {
+        await VerifyNoDiagnosticAsync(@"
+struct Foo 
+{
+    public static bool operator ==(Foo left, string right) => left.Equals(right);
+    public static bool operator !=(Foo left, string right) => !(left == right);
+}
+class C
+{
+    public Foo F { get; } 
+    void M(C c)
+    {
+        if (c != null && c.F == ""someStr"") { }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseConditionalAccess)]
     public async Task TestNoDiagnostic_LogicalAnd_NullableType()
     {
         await VerifyNoDiagnosticAsync(@"


### PR DESCRIPTION
If we have the following expression and the field F is a value type then we cannot apply RCS1146 as this will mean that a different overload of `==` is used (and one may not exist).
```
c != null && c.F == "someStr"
```

We know that the `==` operator exists and works correctly for in-built value types like int so the diagnostic can still be suggested for those cases.