### PR TITLE
Fix RCS1187

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Append `?` to nullable reference types.
 - Fix [RCS1179](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1179.md) ([#1129](https://github.com/JosefPihrt/Roslynator/pull/1129)).
 - Fix [RCS0060](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS0060.md) ([#1139](https://github.com/JosefPihrt/Roslynator/pull/1139)).
+- Fix [RCS1187](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1187.md) ([#1150](https://github.com/JosefPihrt/Roslynator/pull/1150)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add SECURITY.md ([#1147](https://github.com/josefpihrt/roslynator/pull/1147))
 
+### Fixed
+
+- Fix [RCS1187](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1187.md) ([#1150](https://github.com/JosefPihrt/Roslynator/pull/1150)).
+
 ## [4.4.0] - 2023-08-01
 
 ### Added
@@ -45,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Append `?` to nullable reference types.
 - Fix [RCS1179](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1179.md) ([#1129](https://github.com/JosefPihrt/Roslynator/pull/1129)).
 - Fix [RCS0060](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS0060.md) ([#1139](https://github.com/JosefPihrt/Roslynator/pull/1139)).
-- Fix [RCS1187](https://github.com/JosefPihrt/Roslynator/blob/main/docs/analyzers/RCS1187.md) ([#1150](https://github.com/JosefPihrt/Roslynator/pull/1150)).
 
 ## [4.3.0] - 2023-04-24
 

--- a/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
@@ -85,8 +85,11 @@ internal static class UseConstantInsteadOfFieldAnalysis
                 return false;
 
             // Changing a static field to a constant changes the meaning of that symbol in the decorators.
-            foreach (IdentifierNameSyntax identifierName in value.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            foreach (SyntaxNode node in value.DescendantNodesAndSelf())
             {
+                if (node is not IdentifierNameSyntax identifierName)
+                    continue;
+
                 if (identifierName.Identifier.ValueText != fieldSymbol.Name)
                     continue;
 

--- a/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
+++ b/src/Common/CSharp/Analysis/UseConstantInsteadOfFieldAnalysis.cs
@@ -85,7 +85,7 @@ internal static class UseConstantInsteadOfFieldAnalysis
                 return false;
 
             // Changing a static field to a constant changes the meaning of that symbol in the decorators.
-            foreach (var identifierName in value.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            foreach (IdentifierNameSyntax identifierName in value.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
             {
                 if (identifierName.Identifier.ValueText != fieldSymbol.Name)
                     continue;

--- a/src/Tests/Analyzers.Tests/RCS1187UseConstantInsteadOfFieldTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1187UseConstantInsteadOfFieldTests.cs
@@ -88,4 +88,17 @@ class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.UseConstantInsteadOfField)]
+    public async Task TestNoDiagnostic_SelfReference()
+    {
+        await VerifyNoDiagnosticAsync(@"
+using System;
+
+class C
+{
+    private static readonly Double Double = Double.Epsilon; 
+}
+");
+    }
 }


### PR DESCRIPTION
Changing a static field to a constant changes the meaning of that symbol in the decorators. For example, applying RCS1187 in the following example will lead to a compile-time error (CS0110):
```
    private static readonly LogLevel LogLevel = LogLevel.Information;
```