### PR TITLE
Fix RCS1197 

### DIFF
--- a/src/Tests/Analyzers.Tests/RCS1197OptimizeStringBuilderAppendCallTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1197OptimizeStringBuilderAppendCallTests.cs
@@ -371,6 +371,71 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeStringBuilderAppendCall)]
+    public async Task Test_InterpolatedRawString_ContainingQuotes()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Text;
+class C
+{
+    void M()
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.Append([|$""""""<a href=""somelink"">{s}</a>""""""|]);
+    }
+}
+", @"
+using System.Text;
+class C
+{
+    void M()
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.Append(""""""<a href=""somelink"">"""""").Append(s).Append(""""""</a>"""""");
+    }
+}
+", options: WellKnownCSharpTestOptions.Default_CSharp11);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeStringBuilderAppendCall)]
+    public async Task Test_InterpolatedMultilineRawString_ContainingQuotes()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Text;
+class C
+{
+    void M()
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.Append([|$""""""
+                    <a href=""somelink"">{s}</a>
+""""""|]
+        );
+    }
+}
+", @"
+using System.Text;
+class C
+{
+    void M()
+    {
+        string s = null;
+        var sb = new StringBuilder();
+        sb.Append(""""""
+                    <a href=""somelink"">
+""""""
+        ).Append(s).Append(""""""
+</a>
+""""""
+);
+    }
+}
+", options: WellKnownCSharpTestOptions.Default_CSharp11);
+    }
+    
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.OptimizeStringBuilderAppendCall)]
     public async Task Test_InterpolatedString_Char()
     {
         await VerifyDiagnosticAndFixAsync(@"

--- a/src/Tests/Tests.Common/Testing/CSharp/WellKnownCSharpTestOptions.cs
+++ b/src/Tests/Tests.Common/Testing/CSharp/WellKnownCSharpTestOptions.cs
@@ -14,6 +14,7 @@ public static class WellKnownCSharpTestOptions
     private static CSharpTestOptions _default_CSharp7_3;
     private static CSharpTestOptions _default_CSharp8;
     private static CSharpTestOptions _default_CSharp9;
+    private static CSharpTestOptions _default_CSharp11;
     private static CSharpTestOptions _default_NullableReferenceTypes;
 
     public static CSharpTestOptions Default_CSharp5
@@ -91,6 +92,19 @@ public static class WellKnownCSharpTestOptions
             return _default_CSharp9;
 
             static CSharpTestOptions Create() => DefaultCSharpTestOptions.Value.WithParseOptions(DefaultCSharpTestOptions.Value.ParseOptions.WithLanguageVersion(LanguageVersion.CSharp9));
+        }
+    }
+    
+    public static CSharpTestOptions Default_CSharp11
+    {
+        get
+        {
+            if (_default_CSharp11 is null)
+                Interlocked.CompareExchange(ref _default_CSharp11, Create(), null);
+
+            return _default_CSharp11;
+
+            static CSharpTestOptions Create() => DefaultCSharpTestOptions.Value.WithParseOptions(DefaultCSharpTestOptions.Value.ParseOptions.WithLanguageVersion(LanguageVersion.CSharp11));
         }
     }
 


### PR DESCRIPTION
C# 11 adds support for multiline interpolated strings. The code fix for RCS1197 currently produced code that cannot compile. 