### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,26 +308,40 @@ jobs:
     needs: [ build_core_and_testing, build_analyzers, build_refactorings, build_code_fixes ]
     runs-on: ubuntu-24.04
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: nuget_*
           path: nuget
           merge-multiple: true
-      - run: dotnet nuget push "*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" --skip-duplicate
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "*.nupkg" -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" --skip-duplicate
         working-directory: nuget
 
   publish_cli_nuget_packages:
     needs: [ build_core_cli, build_framework_cli ]
     runs-on: ubuntu-24.04
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'cli-v')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: nuget_*
           path: nuget
           merge-multiple: true
-      - run: dotnet nuget push "*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" --skip-duplicate
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "*.nupkg" -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" --skip-duplicate
         working-directory: nuget
 
   publish_vs_code_extension:


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (jpihrt in this case).  
- The old `secrets.NUGET_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `jpihrt`).  
   - **Repository owner:** your GitHub org/user (e.g. `dotnet`).  
   - **Repository name:** repository name (e.g. `roslynator`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `build.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.
