### PR TITLE
Fixes .net10 msbuild compatibility issue (#1716)

### DIFF
--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -58,7 +58,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' != 'net10.0'" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="Microsoft.Build" Version="18.0.2" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(RoslynatorMicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynatorCliRoslynVersion)" />


### PR DESCRIPTION
The msbuild version in .net10 has breaking changes from previous versions. This conditionally selects the appropriate version depending on the target framework during build.