### PR TITLE
Fix RCS1166 to report diagnostic when null is on the left side of comparison

### DIFF
--- a/src/Analyzers.CodeFixes/CSharp/CodeFixes/BinaryExpressionCodeFixProvider.cs
+++ b/src/Analyzers.CodeFixes/CSharp/CodeFixes/BinaryExpressionCodeFixProvider.cs
@@ -131,7 +131,11 @@ public sealed class BinaryExpressionCodeFixProvider : BaseCodeFixProvider
                 {
                     SemanticModel semanticModel = await context.GetSemanticModelAsync().ConfigureAwait(false);
 
-                    ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(binaryExpression.Left, context.CancellationToken);
+                    bool nullIsOnLeft = binaryExpression.Left.IsKind(SyntaxKind.NullLiteralExpression);
+                    ExpressionSyntax valueExpression = (nullIsOnLeft) ? binaryExpression.Right : binaryExpression.Left;
+                    ExpressionSyntax nullExpression = (nullIsOnLeft) ? binaryExpression.Left : binaryExpression.Right;
+
+                    ITypeSymbol typeSymbol = semanticModel.GetTypeSymbol(valueExpression, context.CancellationToken);
 
                     string title;
 
@@ -144,7 +148,7 @@ public sealed class BinaryExpressionCodeFixProvider : BaseCodeFixProvider
                     }
                     else
                     {
-                        title = $"Use EqualityComparer<{SymbolDisplay.ToMinimalDisplayString(typeSymbol, semanticModel, binaryExpression.Right.SpanStart, SymbolDisplayFormats.DisplayName)}>.Default";
+                        title = $"Use EqualityComparer<{SymbolDisplay.ToMinimalDisplayString(typeSymbol, semanticModel, nullExpression.SpanStart, SymbolDisplayFormats.DisplayName)}>.Default";
                     }
 
                     CodeAction codeAction = CodeAction.Create(

--- a/src/Analyzers.CodeFixes/CSharp/Refactorings/ValueTypeObjectIsNeverEqualToNullRefactoring.cs
+++ b/src/Analyzers.CodeFixes/CSharp/Refactorings/ValueTypeObjectIsNeverEqualToNullRefactoring.cs
@@ -20,7 +20,9 @@ internal static class ValueTypeObjectIsNeverEqualToNullRefactoring
     {
         SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-        ExpressionSyntax right = binaryExpression.Right;
+        bool nullIsOnLeft = binaryExpression.Left.Kind() == SyntaxKind.NullLiteralExpression;
+        ExpressionSyntax nullExpression = (nullIsOnLeft) ? binaryExpression.Left : binaryExpression.Right;
+        ExpressionSyntax valueExpression = (nullIsOnLeft) ? binaryExpression.Right : binaryExpression.Left;
 
         ExpressionSyntax newNode = null;
 
@@ -28,10 +30,10 @@ internal static class ValueTypeObjectIsNeverEqualToNullRefactoring
             || typeSymbol.ContainsMember<IMethodSymbol>(WellKnownMemberNames.EqualityOperatorName))
         {
             newNode = typeSymbol.GetDefaultValueSyntax(document.GetDefaultSyntaxOptions())
-                .WithTriviaFrom(right)
+                .WithTriviaFrom(nullExpression)
                 .WithFormatterAnnotation();
 
-            return await document.ReplaceNodeAsync(right, newNode, cancellationToken).ConfigureAwait(false);
+            return await document.ReplaceNodeAsync(nullExpression, newNode, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -43,8 +45,8 @@ internal static class ValueTypeObjectIsNeverEqualToNullRefactoring
                 SimpleMemberAccessExpression(
                     SimpleMemberAccessExpression(equalityComparerSymbol.ToMinimalTypeSyntax(semanticModel, binaryExpression.SpanStart), IdentifierName("Default")), IdentifierName("Equals")),
                 ArgumentList(
-                    Argument(binaryExpression.Left.WithoutTrivia()),
-                    Argument(DefaultExpression(typeSymbol.ToMinimalTypeSyntax(semanticModel, right.SpanStart)))));
+                    Argument(valueExpression.WithoutTrivia()),
+                    Argument(DefaultExpression(typeSymbol.ToMinimalTypeSyntax(semanticModel, nullExpression.SpanStart)))));
 
             if (binaryExpression.IsKind(SyntaxKind.NotEqualsExpression))
                 newNode = LogicalNotExpression(newNode);

--- a/src/Analyzers/CSharp/Analysis/ValueTypeObjectIsNeverEqualToNullAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/ValueTypeObjectIsNeverEqualToNullAnalyzer.cs
@@ -45,20 +45,29 @@ public sealed class ValueTypeObjectIsNeverEqualToNullAnalyzer : BaseDiagnosticAn
     private static void Analyze(SyntaxNodeAnalysisContext context, BinaryExpressionSyntax binaryExpression)
     {
         ExpressionSyntax left = binaryExpression.Left;
+        ExpressionSyntax right = binaryExpression.Right;
 
-        if (left?.IsMissing == false)
+        if (left?.IsMissing != false || right?.IsMissing != false)
+            return;
+
+        if (binaryExpression.SpanContainsDirectives())
+            return;
+
+        if (right.Kind() == SyntaxKind.NullLiteralExpression
+            && IsStructButNotNullableOfT(context.SemanticModel.GetTypeSymbol(left, context.CancellationToken)))
         {
-            ExpressionSyntax right = binaryExpression.Right;
-
-            if (right?.Kind() == SyntaxKind.NullLiteralExpression
-                && IsStructButNotNullableOfT(context.SemanticModel.GetTypeSymbol(left, context.CancellationToken))
-                && !binaryExpression.SpanContainsDirectives())
-            {
-                DiagnosticHelpers.ReportDiagnostic(
-                    context,
-                    DiagnosticRules.ValueTypeObjectIsNeverEqualToNull,
-                    binaryExpression);
-            }
+            DiagnosticHelpers.ReportDiagnostic(
+                context,
+                DiagnosticRules.ValueTypeObjectIsNeverEqualToNull,
+                binaryExpression);
+        }
+        else if (left.Kind() == SyntaxKind.NullLiteralExpression
+            && IsStructButNotNullableOfT(context.SemanticModel.GetTypeSymbol(right, context.CancellationToken)))
+        {
+            DiagnosticHelpers.ReportDiagnostic(
+                context,
+                DiagnosticRules.ValueTypeObjectIsNeverEqualToNull,
+                binaryExpression);
         }
     }
 

--- a/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation and Contributors. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Roslynator.CSharp.Analysis;
+using Roslynator.CSharp.CodeFixes;
+using Roslynator.Testing.CSharp;
+using Xunit;
+
+namespace Roslynator.Analyzers.Tests;
+
+public class RCS1166ValueTypeObjectIsNeverEqualToNullTests : AbstractCSharpDiagnosticVerifier<ValueTypeObjectIsNeverEqualToNullAnalyzer, BinaryExpressionCodeFixProvider>
+{
+    public override DiagnosticDescriptor Descriptor { get; } = DiagnosticRules.ValueTypeObjectIsNeverEqualToNull;
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task Test_NullOnLeft_Equals()
+    {
+        await VerifyDiagnosticAsync(@"
+using System.Collections.Immutable;
+
+class C
+{
+    void M()
+    {
+        var a = ImmutableArray<int>.Empty;
+
+        if ([|null == a|])
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task Test_NullOnLeft_NotEquals()
+    {
+        await VerifyDiagnosticAsync(@"
+using System.Collections.Immutable;
+
+class C
+{
+    void M()
+    {
+        var a = ImmutableArray<int>.Empty;
+
+        if ([|null != a|])
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task Test_NullOnLeft_Equals_Int()
+    {
+        await VerifyDiagnosticAsync(@"
+class C
+{
+    void M()
+    {
+        int a = 0;
+
+        if ([|null == a|])
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task Test_NullOnLeft_Equals_Parenthesized()
+    {
+        await VerifyDiagnosticAsync(@"
+using System.Collections.Immutable;
+
+class C
+{
+    void M()
+    {
+        var a = ImmutableArray<int>.Empty;
+
+        if ([|(null) == (a)|])
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task TestNoDiagnostic_NullOnLeft_NullableValueType()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void M()
+    {
+        int? a = null;
+
+        if (null == a)
+        {
+        }
+    }
+}
+");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task TestNoDiagnostic_NullOnLeft_ReferenceType()
+    {
+        await VerifyNoDiagnosticAsync(@"
+class C
+{
+    void M()
+    {
+        string a = null;
+
+        if (null == a)
+        {
+        }
+    }
+}
+");
+    }
+}

--- a/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
@@ -54,44 +54,6 @@ class C
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
-    public async Task Test_NullOnLeft_Equals_Int()
-    {
-        await VerifyDiagnosticAsync(@"
-class C
-{
-    void M()
-    {
-        int a = 0;
-
-        if ([|null == a|])
-        {
-        }
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
-    public async Task Test_NullOnLeft_Equals_Parenthesized()
-    {
-        await VerifyDiagnosticAsync(@"
-using System.Collections.Immutable;
-
-class C
-{
-    void M()
-    {
-        var a = ImmutableArray<int>.Empty;
-
-        if ([|(null) == (a)|])
-        {
-        }
-    }
-}
-");
-    }
-
-    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
     public async Task TestNoDiagnostic_NullOnLeft_NullableValueType()
     {
         await VerifyNoDiagnosticAsync(@"

--- a/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1166ValueTypeObjectIsNeverEqualToNullTests.cs
@@ -88,4 +88,36 @@ class C
 }
 ");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.ValueTypeObjectIsNeverEqualToNull)]
+    public async Task TestFix_NullOnLeft_Equals()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+using System.Collections.Immutable;
+
+class C
+{
+    void M()
+    {
+        var a = ImmutableArray<int>.Empty;
+        if ([|null == a|])
+        {
+        }
+    }
+}
+", @"
+using System.Collections.Immutable;
+
+class C
+{
+    void M()
+    {
+        var a = ImmutableArray<int>.Empty;
+        if (default == a)
+        {
+        }
+    }
+}
+");
+    }
 }


### PR DESCRIPTION
Fixes #1698 