### PR TITLE
Introducing new flag --return-success-on-findings.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [CLI] Suppress error code from Roslynator when it detects issues in code but runs successfully [PR](https://github.com/dotnet/roslynator/pull/1757)
+- [CLI] Suppress error code from Roslynator when it detects issues in code but runs successfully [PR](https://github.com/dotnet/roslynator/pull/1756)
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [CLI] Suppress error code from Roslynator when it detects issues in code but runs successfully [PR](https://github.com/dotnet/roslynator/pull/1756)
+- [CLI] Suppress error code from Roslynator when it detects issues in code but runs successfully ([PR](https://github.com/dotnet/roslynator/pull/1756) by @mdrybak)
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [CLI] Suppress error code from Roslynator when it detects issues in code but runs successfully [PR](https://github.com/dotnet/roslynator/pull/1757)
+
 ### Fixed
 
 - Fix enum contained flags check for partial matches in [RCS1258](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1258) ([PR](https://github.com/dotnet/roslynator/pull/1740) by @ovska)

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -85,7 +85,7 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
     }
 
     private static CommandStatus GetCommandStatus(AnalyzeCommandLineOptions options, ImmutableArray<ProjectAnalysisResult> results)
-        => (options.ReturnSuccessOnFindings || !results.Any(f => f.Diagnostics.Length > 0 || f.CompilerDiagnostics.Length > 0)) ? CommandStatus.Success : CommandStatus.NotSuccess;
+        => (options.ReturnSuccessOnDiagnostics || !results.Any(f => f.Diagnostics.Length > 0 || f.CompilerDiagnostics.Length > 0)) ? CommandStatus.Success : CommandStatus.NotSuccess;
 
     protected override void ProcessResults(IList<AnalyzeCommandResult> results)
     {

--- a/src/CommandLine/Commands/AnalyzeCommand.cs
+++ b/src/CommandLine/Commands/AnalyzeCommand.cs
@@ -81,10 +81,11 @@ internal class AnalyzeCommand : MSBuildWorkspaceCommand<AnalyzeCommandResult>
             results = await codeAnalyzer.AnalyzeSolutionAsync(solution, f => IsMatch(f), cancellationToken);
         }
 
-        return new AnalyzeCommandResult(
-            (results.Any(f => f.Diagnostics.Length > 0 || f.CompilerDiagnostics.Length > 0)) ? CommandStatus.NotSuccess : CommandStatus.Success,
-            results);
+        return new AnalyzeCommandResult(GetCommandStatus(Options, results), results);
     }
+
+    private static CommandStatus GetCommandStatus(AnalyzeCommandLineOptions options, ImmutableArray<ProjectAnalysisResult> results)
+        => (options.ReturnSuccessOnFindings || !results.Any(f => f.Diagnostics.Length > 0 || f.CompilerDiagnostics.Length > 0)) ? CommandStatus.Success : CommandStatus.NotSuccess;
 
     protected override void ProcessResults(IList<AnalyzeCommandResult> results)
     {

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -39,6 +39,11 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
         HelpText = "Indicates whether suppressed diagnostics should be reported.")]
     public bool ReportSuppressedDiagnostics { get; set; }
 
+    [Option(
+        longName: "return-success-on-findings",
+        HelpText = "Indicates whether to return exit code 0 on runs when findings are reported.")]
+    public bool ReturnSuccessOnFindings { get; set; }
+
     internal bool ValidateOutputFormat()
     {
         return ParseHelpers.TryParseOutputFormat(OutputFormat);

--- a/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
+++ b/src/CommandLine/Options/AnalyzeCommandLineOptions.cs
@@ -40,9 +40,9 @@ public class AnalyzeCommandLineOptions : AbstractAnalyzeCommandLineOptions
     public bool ReportSuppressedDiagnostics { get; set; }
 
     [Option(
-        longName: "return-success-on-findings",
-        HelpText = "Indicates whether to return exit code 0 on runs when findings are reported.")]
-    public bool ReturnSuccessOnFindings { get; set; }
+        longName: "return-success-on-diagnostics",
+        HelpText = "Indicates whether to return exit code 0 on runs when diagnostics are reported.")]
+    public bool ReturnSuccessOnDiagnostics { get; set; }
 
     internal bool ValidateOutputFormat()
     {


### PR DESCRIPTION
Fixes #1693.
New flag: --return-success-on-findings is introduced. When it's used, CLI will return 0 even if findings are reported.
Naming isn't really creative and I'm not really emotionally attached to it, so feel free to suggest some new name and I'll just change it.
Tagging @davewichers as the issue reporter.