### PR TITLE
[CLI] Fix .slnx parsing on .NET 10 SDK

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [CLI] Fix `.slnx` parsing on .NET 10 SDK by suppressing the bundled ref-only `Microsoft.Build.Framework.dll`, so MSBuildLocator loads the SDK's full implementation at runtime (fixes [#1729](https://github.com/dotnet/roslynator/issues/1729), [#1748](https://github.com/dotnet/roslynator/issues/1748), [#1716](https://github.com/dotnet/roslynator/issues/1716))
+
 ## [4.15.0] - 2025-12-14
 
 ### Added

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -58,7 +58,15 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Build" Version="18.4.0" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <!-- Suppress bundling of Microsoft.Build.Framework.dll: the NuGet copy is a
+         ref-only assembly that lacks internal types (e.g. FileUtilities) which
+         the SDK's full Microsoft.Build.dll calls when parsing .slnx solutions.
+         MSBuildLocator will load the matching full implementation from the SDK
+         at runtime. See https://github.com/dotnet/roslynator/issues/1729. -->
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.4.0" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(RoslynatorMicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynatorCliRoslynVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(RoslynatorCliRoslynVersion)" />


### PR DESCRIPTION
## Summary

Fix `.slnx` solution parsing for users running on the .NET 10 SDK, which currently crashes with `TypeLoadException: Could not load type 'Microsoft.Build.Framework.FileUtilities'`.

Fixes #1729, #1748, #1716.

## Root cause

The bundled `Microsoft.Build.Framework.dll` from NuGet is a ref-only assembly stripped of `internal` types. When MSBuild 18 (.NET 10 SDK) parses a `.slnx` solution, `Microsoft.Build.dll` calls the internal `Microsoft.Build.Framework.FileUtilities` type — which only exists in the SDK's full implementation, not in the ref assembly the tool ships. .NET's assembly resolution prefers the locally-bundled ref copy over the SDK's full one, so the type lookup fails.

This was latent on prior SDKs: MSBuild 17's `SolutionFile.Parse` codepath didn't call across into Framework internals, so the wrong-shadowing-of-the-ref-assembly never triggered. SDK 10's refactored slnx parser exposed it.

## Fix

Add explicit `<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />` for net9 and net10, which stops the package from depositing its `.dll` into the tool output. `MSBuildLocator` then loads the SDK's full implementation at runtime, as intended.

Also split the existing `Microsoft.Build` reference by TFM, since `Microsoft.Build` 18.x targets only net10 (and net48) — net9 keeps 17.14.28, net10 moves to 18.4.0.

net8 is intentionally not touched: `.slnx` requires SDK 9.0.200+, so net8 users can't reach the failing codepath. If parity is desired, the same pattern can extend to net8 in a follow-up.

## Test plan

- [x] `dotnet build -p:RoslynatorDotNetCli=true` on net8/net9/net10 — all succeed; net9/net10 outputs no longer contain `Microsoft.Build.Framework.dll`
- [x] `dotnet pack` produces a tool package, locally installed
- [x] `roslynator list-symbols Periphery.slnx --depth member --visibility public` — succeeds on a `.slnx` solution under SDK 10 with no `--msbuild-path` pin (previously crashed with `TypeLoadException`)
- [ ] Maintainer regression check across other CLI commands (`analyze`, `fix`, `format`, etc.) — should be unaffected since the fix is purely about which `.dll` is bundled, not about runtime API usage
