### PR TITLE
Fix analyzer RCS1060

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS1060](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1060) to ignore classes marked with `file` modifier ([PR](https://github.com/dotnet/roslynator/pull/1777) by @cbersch)
 - Fix enum contained flags check for partial matches in [RCS1258](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1258) ([PR](https://github.com/dotnet/roslynator/pull/1740) by @ovska)
 - Fix analyzer [RCS1146](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1146) ([PR](https://github.com/dotnet/roslynator/pull/1747))
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -60,7 +60,11 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                 {
                     Analyze(namespaceDeclaration.Members);
                 }
-                else if (SyntaxFacts.IsTypeDeclaration(member.Kind()) && !member.Modifiers.Contains(SyntaxKind.FileKeyword))
+                else if (SyntaxFacts.IsTypeDeclaration(member.Kind())
+#if ROSLYN_4_4
+                    && !member.Modifiers.Contains(SyntaxKind.FileKeyword)
+#endif
+                    )
                 {
                     if (firstTypeDeclaration is null)
                     {

--- a/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analysis/DeclareEachTypeInSeparateFileAnalyzer.cs
@@ -60,7 +60,7 @@ public sealed class DeclareEachTypeInSeparateFileAnalyzer : BaseDiagnosticAnalyz
                 {
                     Analyze(namespaceDeclaration.Members);
                 }
-                else if (SyntaxFacts.IsTypeDeclaration(member.Kind()))
+                else if (SyntaxFacts.IsTypeDeclaration(member.Kind()) && !member.Modifiers.Contains(SyntaxKind.FileKeyword))
                 {
                     if (firstTypeDeclaration is null)
                     {

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -16,69 +16,69 @@ public class RCS1060DeclareEachTypeInSeparateFileTests : AbstractCSharpDiagnosti
     public async Task Test_Namespace()
     {
         await VerifyDiagnosticAndFixAsync("""
-            namespace N
-            {
-                public class [|C1|]
-                {
-                }
+namespace N
+{
+    public class [|C1|]
+    {
+    }
 
-                public class [|C2|]
-                {
-                }
-            }
-            """, """
-            namespace N
-            {
-                public class C2
-                {
-                }
-            }
-            """);
+    public class [|C2|]
+    {
+    }
+}
+""", """
+namespace N
+{
+    public class C2
+    {
+    }
+}
+""");
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
     public async Task Test_FileScopedNamespace()
     {
         await VerifyDiagnosticAndFixAsync("""
-            namespace N;
+namespace N;
 
-            public class [|C1|]
-            {
-            }
+public class [|C1|]
+{
+}
 
-            public class [|C2|]
-            {
-            }
-            """, """
-            namespace N;
+public class [|C2|]
+{
+}
+""", """
+namespace N;
 
-            public class C2
-            {
-            }
-            """);
+public class C2
+{
+}
+""");
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
     public async Task Test_FirstClassWithFileKeyword_NoDiagnostic()
     {
         await VerifyNoDiagnosticAsync("""
-            namespace N
-            {
-                file class C1;
-                public class C2;
-            }
-           """);
+namespace N
+{
+    file class C1;
+    public class C2;
+}
+""");
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
     public async Task Test_LastClassWithFileKeyword_NoDiagnostic()
     {
         await VerifyNoDiagnosticAsync("""
-            namespace N
-            {
-                public class C1;
-                file class C2;
-            }
-           """);
+namespace N
+{
+    public class C1;
+    file class C2;
+}
+""");
     }
 }

--- a/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1060DeclareEachTypeInSeparateFileTests.cs
@@ -16,45 +16,69 @@ public class RCS1060DeclareEachTypeInSeparateFileTests : AbstractCSharpDiagnosti
     public async Task Test_Namespace()
     {
         await VerifyDiagnosticAndFixAsync("""
-namespace N
-{
-    public class [|C1|]
-    {
-    }
+            namespace N
+            {
+                public class [|C1|]
+                {
+                }
 
-    public class [|C2|]
-    {
-    }
-}
-""", """
-namespace N
-{
-    public class C2
-    {
-    }
-}
-""");
+                public class [|C2|]
+                {
+                }
+            }
+            """, """
+            namespace N
+            {
+                public class C2
+                {
+                }
+            }
+            """);
     }
 
     [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
     public async Task Test_FileScopedNamespace()
     {
         await VerifyDiagnosticAndFixAsync("""
-namespace N;
+            namespace N;
 
-public class [|C1|]
-{
-}
+            public class [|C1|]
+            {
+            }
 
-public class [|C2|]
-{
-}
-""", """
-namespace N;
+            public class [|C2|]
+            {
+            }
+            """, """
+            namespace N;
 
-public class C2
-{
-}
-""");
+            public class C2
+            {
+            }
+            """);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_FirstClassWithFileKeyword_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+            namespace N
+            {
+                file class C1;
+                public class C2;
+            }
+           """);
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.DeclareEachTypeInSeparateFile)]
+    public async Task Test_LastClassWithFileKeyword_NoDiagnostic()
+    {
+        await VerifyNoDiagnosticAsync("""
+            namespace N
+            {
+                public class C1;
+                file class C2;
+            }
+           """);
     }
 }


### PR DESCRIPTION
* Ignore classes with `file` modifier, because that expresses an explicit design choice which must be equivalent to ignoring the diagnostic.
Fix #1775 