### PR TITLE
Fix RCS1118 to not report local variable passed as 'in' argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix analyzer [RCS1118](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1118) to not report local variable passed as 'in' argument ([PR](https://github.com/dotnet/roslynator/pull/1782) by @NoahStolk)
 - Fix analyzer [RCS1074](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1074) ([PR](https://github.com/dotnet/roslynator/pull/1768) by @cbersch)
 - Fix enum contained flags check for partial matches in [RCS1258](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1258) ([PR](https://github.com/dotnet/roslynator/pull/1740) by @ovska)
 - Fix analyzer [RCS1146](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1146) ([PR](https://github.com/dotnet/roslynator/pull/1747))

--- a/src/Analyzers/CSharp/Analysis/MarkLocalVariableAsConst/MarkLocalVariableAsConstWalker.cs
+++ b/src/Analyzers/CSharp/Analysis/MarkLocalVariableAsConst/MarkLocalVariableAsConstWalker.cs
@@ -33,6 +33,17 @@ internal class MarkLocalVariableAsConstWalker : AssignedExpressionWalker
             Result = true;
     }
 
+    public override void VisitArgument(ArgumentSyntax node)
+    {
+        if (node.RefKindKeyword.IsKind(SyntaxKind.InKeyword)
+            && IsLocalReference(node.Expression))
+        {
+            Result = true;
+        }
+
+        base.VisitArgument(node);
+    }
+
     public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
         if (node.IsParentKind(SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.AddressOfExpression)

--- a/src/Tests/Analyzers.Tests/RCS1118MarkLocalVariableAsConstTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1118MarkLocalVariableAsConstTests.cs
@@ -158,4 +158,34 @@ public static class C
     }
 }");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MarkLocalVariableAsConst)]
+    public async Task Test_InParameter_WithoutInKeyword()
+    {
+        await VerifyDiagnosticAndFixAsync(@"
+public static class C
+{
+    static void Foo()
+    {
+        [|int|] x = 0;
+        Bar(x);
+    }
+
+    public static void Bar(in int p)
+    {
+    }
+}", @"
+public static class C
+{
+    static void Foo()
+    {
+        const int x = 0;
+        Bar(x);
+    }
+
+    public static void Bar(in int p)
+    {
+    }
+}");
+    }
 }

--- a/src/Tests/Analyzers.Tests/RCS1118MarkLocalVariableAsConstTests.cs
+++ b/src/Tests/Analyzers.Tests/RCS1118MarkLocalVariableAsConstTests.cs
@@ -122,4 +122,40 @@ public static class C
     }
 }");
     }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MarkLocalVariableAsConst)]
+    public async Task TestNoDiagnostic_InArgument()
+    {
+        await VerifyNoDiagnosticAsync(@"
+public static class C
+{
+    static void Foo()
+    {
+        int x = 0;
+        Bar(in x);
+    }
+
+    public static void Bar(in int p)
+    {
+    }
+}");
+    }
+
+    [Fact, Trait(Traits.Analyzer, DiagnosticIdentifiers.MarkLocalVariableAsConst)]
+    public async Task TestNoDiagnostic_InArgument_RefReadOnlyParameter()
+    {
+        await VerifyNoDiagnosticAsync(@"
+public static class C
+{
+    static void Foo()
+    {
+        int x = 0;
+        Bar(in x);
+    }
+
+    public static void Bar(ref readonly int p)
+    {
+    }
+}");
+    }
 }


### PR DESCRIPTION
Fixes #1781

RCS1118 reports a local variable that is later passed to a parameter with an explicit `in` argument keyword. Marking such a local as const produces code that does not compile, because a constant cannot be passed by readonly reference.

Added two new tests: one for an `in` parameter and one for a `ref readonly` parameter. Both fail on `main` and pass with the fix.