### PR TITLE
[CLI] Load MSBuild assemblies from the .NET SDK, never from NuGet

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1146](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1146) ([PR](https://github.com/dotnet/roslynator/pull/1747))
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))
 - [CLI] Fix `fix` command ignoring `--include` / `--exclude` file filter ([PR](https://github.com/dotnet/roslynator/pull/1758) by @hashiiiii)
+- [CLI] Fix loading of projects and solutions on .NET 10 SDK ([PR](https://github.com/dotnet/roslynator/pull/1783) by @charles8051)
 
 ## [4.15.0] - 2025-12-14
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix analyzer [RCS1146](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1146) ([PR](https://github.com/dotnet/roslynator/pull/1747))
 - Fix analyzer [RCS1194](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1194) ([PR](https://github.com/dotnet/roslynator/pull/1733))
 - [CLI] Fix `fix` command ignoring `--include` / `--exclude` file filter ([PR](https://github.com/dotnet/roslynator/pull/1758) by @hashiiiii)
-- [CLI] Fix loading of projects and solutions on .NET 10 SDK ([PR](https://github.com/dotnet/roslynator/pull/1783) by @charles8051)
+- [CLI] Fix loading of projects and solutions on .NET 10 SDK ([PR](https://github.com/dotnet/roslynator/pull/1783))
 
 ## [4.15.0] - 2025-12-14
 

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -56,10 +56,67 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-h4j7-5rxr-p4wc" />
   </ItemGroup>
 
+  <!--
+    MSBuild is loaded from the .NET SDK at run time by MSBuildLocator. Its assemblies are a matched
+    set that is versioned and internally coupled, so a copy deployed with the tool must never be
+    mixed with the engine from the user's SDK. The runtime always prefers an assembly found next to
+    the app over anything MSBuildLocator can resolve, so any copy we deploy silently wins and the
+    SDK's is never loaded, which fails as TypeLoadException or MissingMethodException as soon as the
+    two builds diverge. Reference the packages for compilation only (ExcludeAssets="runtime") so that
+    none of them are deployed and MSBuildLocator resolves the whole set from the SDK.
+    Version matching is not an alternative: the user's SDK patch level is unknown and moves
+    independently of Roslynator's releases. See https://github.com/dotnet/roslynator/issues/1729.
+  -->
+  <PropertyGroup>
+    <!--
+      These versions select compile-time reference assemblies only, so their contents are
+      irrelevant; what matters is that they match what the restore graph already resolves. Pinning
+      a single version across all target frameworks instead would downgrade deployed dependencies
+      of these packages, such as System.Reflection.MetadataLoadContext.
+    -->
+    <RoslynatorMSBuildVersion Condition="'$(TargetFramework)' == 'net8.0'">17.7.2</RoslynatorMSBuildVersion>
+    <RoslynatorMSBuildVersion Condition="'$(TargetFramework)' == 'net9.0'">17.14.28</RoslynatorMSBuildVersion>
+    <RoslynatorMSBuildVersion Condition="'$(TargetFramework)' == 'net10.0'">18.0.2</RoslynatorMSBuildVersion>
+    <!--
+      Microsoft.Build.Tasks.Core and Microsoft.Build.Utilities.Core come from
+      Microsoft.CodeAnalysis.Workspaces.MSBuild, which resolves them at 17.7.2 for every target
+      framework. Raising them to match the versions above would pull in
+      System.Security.Cryptography.Xml 9.0.0, which has open advisories.
+    -->
+    <RoslynatorMSBuildTasksVersion>17.7.2</RoslynatorMSBuildTasksVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(RoslynatorMSBuildVersion)' != ''">
+    <PackageReference Include="Microsoft.Build" Version="$(RoslynatorMSBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(RoslynatorMSBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="$(RoslynatorMSBuildVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RoslynatorMSBuildTasksVersion)" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RoslynatorMSBuildTasksVersion)" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+  <!--
+    Guards the rule above. A new or updated dependency can start pulling one of these assemblies in
+    again at any time, and the result is a crash on the user's machine rather than a build failure
+    here, so fail the build instead. Microsoft.Build.Locator is deliberately deployed and excluded.
+  -->
+  <PropertyGroup>
+    <RoslynatorSdkOwnedAssemblies>;Microsoft.Build;Microsoft.Build.Framework;Microsoft.Build.Tasks.Core;Microsoft.Build.Utilities.Core;Microsoft.NET.StringTools;</RoslynatorSdkOwnedAssemblies>
+  </PropertyGroup>
+
+  <Target Name="RoslynatorVerifyNoSdkOwnedAssembliesDeployed"
+          AfterTargets="ResolveAssemblyReferences"
+          Condition="'$(RoslynatorMSBuildVersion)' != ''">
+    <ItemGroup>
+      <RoslynatorDeployedSdkOwnedAssembly
+        Include="@(ReferenceCopyLocalPaths)"
+        Condition="'%(Extension)' == '.dll' AND $(RoslynatorSdkOwnedAssemblies.Contains(';%(Filename);'))" />
+    </ItemGroup>
+    <Error Condition="'@(RoslynatorDeployedSdkOwnedAssembly)' != ''"
+           Text="These assemblies must be loaded from the .NET SDK at run time, but they are about to be deployed with the tool: @(RoslynatorDeployedSdkOwnedAssembly->'%(Filename)%(Extension)', ', '). Add a PackageReference with ExcludeAssets=&quot;runtime&quot; for whichever package now brings them in." />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Build" Version="18.0.2" ExcludeAssets="runtime" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(RoslynatorMicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynatorCliRoslynVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(RoslynatorCliRoslynVersion)" />


### PR DESCRIPTION
## Summary

The CLI deploys its own copies of MSBuild's assemblies. Those copies always win over the ones in the user's .NET SDK, so the SDK's MSBuild engine ends up running against a different build of its own halves. On SDK 10 patches carrying MSBuild 18.6 or later this fails immediately with `TypeLoadException: Could not load type 'Microsoft.Build.Framework.FileUtilities'`.

This makes the tool stop deploying MSBuild entirely and lets `MSBuildLocator` resolve the whole set from the SDK, for net8.0, net9.0 and net10.0.

Fixes #1729, #1748, #1716. Supersedes #1762 — the diagnosis there is what led here, thanks @charles8051.

## Root cause

Roslynator cannot ship MSBuild: opening a project requires *the user's* MSBuild, because that is what knows their SDK's targets. So `MSBuildWorkspaceCommand` registers `MSBuildLocator`, which resolves MSBuild out of the installed SDK.

`MSBuildLocator` hooks `AssemblyLoadContext.Resolving`, and that only fires when an assembly is **not** found next to the app. Any copy we deploy therefore wins silently and the locator is never consulted for it.

`ExcludeAssets="runtime"` was set on `Microsoft.Build`, but that setting is not inherited by a package's dependencies. From `project.assets.json` before this change:

```
Microsoft.Build/18.0.2            runtime: ['lib/net10.0/_._']                        ← excluded
Microsoft.Build.Framework/18.0.2  runtime: ['lib/net10.0/Microsoft.Build.Framework.dll'] ← deployed
```

Three more were deployed the same way, pulled in transitively by `Microsoft.CodeAnalysis.Workspaces.MSBuild`: `Microsoft.Build.Tasks.Core` and `Microsoft.Build.Utilities.Core` at **17.7.2**, plus `Microsoft.NET.StringTools`.

MSBuild's assemblies are a matched set — versioned together and coupled through `InternalsVisibleTo` — so mixing builds is the defect. Concretely, MSBuild moved shared helpers into `Microsoft.Build.Framework` between 18.4 and 18.6:

| `Microsoft.Build.Framework` | `lib` size | contains `FileUtilities` |
|---|---|---|
| 18.0.2 | 269,608 | no |
| 18.4.0 | 305,424 | no |
| 18.6.3 | 529,712 | **yes** |
| 18.8.2 | 1,051,472 | **yes** |

An SDK whose engine is 18.6+ asks for a type that the deployed 18.0.2 build does not have. Nothing changed on Roslynator's side; MSBuild 17's solution parser simply never called across into `Framework` internals on that path, and 18's `.slnx` parser does.

Note this is not specific to `.slnx` — #1729 reports `MissingFieldException` on a plain console project. It is general assembly shadowing, which is why net8.0 is covered here too: the TFM of an installed tool is frozen at install time, so anyone who installed under SDK 8 or 9 and later moved to SDK 10 keeps that asset and hits the same mismatch.

## Why not just bump the MSBuild version

Because it would only hide this particular crash. To make deploying MSBuild work you would have to match the version on the user's machine, and that is unknowable — their SDK patch level varies per machine and moves on Microsoft's schedule, not Roslynator's. Any version chosen is wrong for someone, and the next SDK patch that moves anything internal breaks it again. Deploying none of them is the only stable answer.

## The fix

All five packages are referenced with `ExcludeAssets="runtime"`, so only the compile-time reference assemblies are used and nothing is deployed. `net48` is untouched — it resolves MSBuild from a Visual Studio install and has a different risk profile.

Versions are pinned to exactly what the restore graph already resolves, which keeps the deployed dependency set byte-identical. Two things ruled out the tidier alternatives:

- Raising `Tasks.Core`/`Utilities.Core` to match the others pulls in `System.Security.Cryptography.Xml` 9.0.0, which has open advisories (32 new `NU1903` warnings).
- Collapsing to one version for all TFMs downgrades deployed packages — `System.Reflection.MetadataLoadContext` 9.0.0 → 7.0.0 on net9.0 and net10.0.

Since these are compile-time references only, their contents no longer matter; the comments in the file record why the values are what they are.

## Regression guard

A new build target fails the build if any of these assemblies is about to be deployed. This class of bug is invisible at build time and only shows up as a crash on a user's machine, and a future Roslyn or MSBuild bump could reintroduce a copy at any point. Verified to fire:

```
error : These assemblies must be loaded from the .NET SDK at run time, but they are about to be
deployed with the tool: Microsoft.Build.Framework.dll. Add a PackageReference with
ExcludeAssets="runtime" for whichever package now brings them in.
```

## Testing

| Check | Result |
|---|---|
| Restore graph vs. `main` | identical, all three TFMs |
| New advisory warnings | none |
| Build net8.0 / net9.0 / net10.0 | 0 errors, 0 warnings |
| `Microsoft.Build*` / `StringTools` in output | none, all three TFMs |
| Dangling `deps.json` entries | none |
| `list-symbols` on a `.csproj` | exit 0, identical output on all three TFMs |
| `list-symbols` on a `.slnx` | exit 0, net9.0 and net10.0 |
| MSBuild resolved from | SDK 9.0.302 (net9 build), SDK 10.0.101 (net10 build) |
| Guard fires when an exclusion is removed | yes, all three TFMs |

**Not verified:** the SDK available here is 10.0.101, which ships MSBuild 18.0.6 — before the 18.6 change. So this proves the assemblies are gone and nothing regressed, but not that the reported `TypeLoadException` disappears. That needs a check on an SDK 10 patch with MSBuild 18.6 or later. @charles8051, if you still have the environment from #1762, would you mind confirming?
